### PR TITLE
Print all sensor data with keeping format

### DIFF
--- a/CubeIDE/Nucleo_G491RE/Core/Inc/sensor.h
+++ b/CubeIDE/Nucleo_G491RE/Core/Inc/sensor.h
@@ -109,6 +109,10 @@ static const uint8_t PS_CHANNEL_ARRAY_PCA9457[4] = {0x00,0x03,0x04,0x07};//KJS-0
 
 // debug buffer
 uint8_t debug_buffer[2048];
+uint8_t gyro_buffer[512];
+uint8_t acc_buffer[512];
+uint8_t adc_buffer[512];
+uint8_t i2s_buffer[512];
 
 struct sensor_params {
 	//buffer

--- a/CubeIDE/Nucleo_G491RE/Core/Src/main.c
+++ b/CubeIDE/Nucleo_G491RE/Core/Src/main.c
@@ -697,22 +697,14 @@ void StartTXBUFFTask(void const * argument)
   for(;;)
   {
 	  txbuff_update();
-	  /*
-	  sprintf(debug_buffer, "acc[0]:%d acc[1]:%d acc[2]:%d \r\n", sp.acc_print[0], sp.acc_print[1], sp.acc_print[2]);
+	  sprintf(acc_buffer, "acc[0]:%d acc[1]:%d acc[2]:%d\r\n", sp.acc_print[0], sp.acc_print[1], sp.acc_print[2]);
+	  sprintf(gyro_buffer, "gyro[0]:%d gyro[1]:%d gyro[2]:%d\r\n", sp.gyro_print[0], sp.gyro_print[1], sp.gyro_print[2]);
+	  sprintf(adc_buffer, "adc[0]:%d adc[1]:%d adc[2]:%d adc[3]:%d\r\n", sp.adc_print[0], sp.adc_print[1], sp.adc_print[2], sp.adc_print[3]);
+	  sprintf(i2s_buffer, "i2s[0]:%d i2s[1]:%d i2s[2]:%d i2s[3]:%d\r\n", sp.i2s_buff_sifted[0], sp.i2s_buff_sifted[1], sp.i2s_buff_sifted[2], sp.i2s_buff_sifted[3]);
+	  sprintf(debug_buffer, "%s%s%s%s\r\n", acc_buffer, gyro_buffer, adc_buffer, i2s_buffer);
 	  HAL_UART_Transmit(&hlpuart1, debug_buffer, 2048, 100);
-	  HAL_Delay(100);
-	  sprintf(debug_buffer, "gyro[0]:%d gyro[1]:%d gyro[2]:%d \r\n", sp.gyro_print[0], sp.gyro_print[1], sp.gyro_print[2]);
-	  HAL_UART_Transmit(&hlpuart1, debug_buffer, 2048, 100);
-	  HAL_Delay(100);
-	  sprintf(debug_buffer, "ps[0]:%d ps[1]:%d ps[2]:%d ps[3]:%d\r\n", sp.ps_print[0], sp.ps_print[1], sp.ps_print[2], sp.ps_print[3]);
-	  HAL_UART_Transmit(&hlpuart1, debug_buffer, 2048, 100);
-	  HAL_Delay(100);
-	  sprintf(debug_buffer, "adc[0]:%d adc[1]:%d adc[2]:%d adc[3]:%d\r\n", sp.adc_print[0], sp.adc_print[1], sp.adc_print[2], sp.adc_print[3]);
-	  HAL_UART_Transmit(&hlpuart1, debug_buffer, 2048, 100);
-	  HAL_Delay(100);
-	  */
-	  sprintf(debug_buffer, "i2s[0]:%d i2s[1]:%d i2s[2]:%d i2s[3]:%d \r\n", sp.i2s_buff_sifted[0], sp.i2s_buff_sifted[1], sp.i2s_buff_sifted[2], sp.i2s_buff_sifted[3]);
-	  HAL_UART_Transmit(&hlpuart1, debug_buffer, 2048, 100);
+	  // 2000[ms] is very important value.
+	  // Changing delay time or adding HAL_Delay causes I2S reading error.
 	  osDelay(2000);
   }
   /* USER CODE END StartTXBUFFTask */


### PR DESCRIPTION
全てのセンサデータを1つのbufferに入れて、一気にシリアルモニタに出力するようにしました。

これまではシリアルモニタに表示されるセンサデータがぐちゃぐちゃになっていました。
これは、`HAL_UART_Transmit`が近い時間内で何回も呼ばれたときに、各文字列が表示されるタイミングの問題でぐちゃぐちゃに入り乱れていたからだと思います。