### PR TITLE
Use SPI dma callback only for SPI3

### DIFF
--- a/CubeIDE/Nucleo_G491RE/Core/Src/main.c
+++ b/CubeIDE/Nucleo_G491RE/Core/Src/main.c
@@ -889,6 +889,27 @@ void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s) {
     //HAL_I2S_Receive_DMA( hi2s, (uint16_t*)&I2S_RX_BUFFER, MIC_BUFF_SIZE);
 }
 
+void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi) {
+	// hspi3: PR2 SPI slave
+	if (hspi->Instance == SPI3) {
+	  if(sp.rxbuff[0] == READ_COMMAND){
+		  sp.rx_counter += 1;
+		  //taskENTER_CRITICAL();
+		  HAL_SPI_Transmit_DMA(hspi, sp.txbuff, sizeof(sp.txbuff));
+		  //taskEXIT_CRITICAL();
+	  }else{
+		  sp.error_count += 1;
+		  HAL_SPI_Receive_DMA(hspi, sp.rxbuff, 1);
+	  }
+	}
+}
+
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi) {
+	// hspi3: PR2 SPI slave
+	if (hspi->Instance == SPI3) {
+	  HAL_SPI_Receive_DMA(hspi, sp.rxbuff, 1);
+	}
+}
 /* USER CODE END 4 */
 
 /* USER CODE BEGIN Header_StartSPIslaveTask */

--- a/CubeIDE/Nucleo_G491RE/Core/Src/sensor.c
+++ b/CubeIDE/Nucleo_G491RE/Core/Src/sensor.c
@@ -466,29 +466,6 @@ void ps_update(I2C_HandleTypeDef *hi2c){
 	}
 }
 
-void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi) {
-	  if(sp.rxbuff[0] == READ_COMMAND){
-		  sp.rx_counter += 1;
-		  //taskENTER_CRITICAL();
-		  HAL_SPI_Transmit_DMA(hspi, sp.txbuff, sizeof(sp.txbuff));
-		  //taskEXIT_CRITICAL();
-	  }else{
-		  sp.error_count += 1;
-		  HAL_SPI_Receive_DMA(hspi, sp.rxbuff, 1);
-	  }
-}
-
-/*
-void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi) {
-  txBuffer[0] = rxBuffer[0];
-  HAL_SPI_Transmit_DMA(hspi, txBuffer, 1);  // Tx DMA start
-}
-*/
-
-void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi) {
-	  HAL_SPI_Receive_DMA(hspi, sp.rxbuff, 1);
-}
-
 void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
 {
 	switch(sp.i2c1_dma_flag){


### PR DESCRIPTION
DMAのコールバック関数の中で、同じ通信インターフェースの中でも何番のインターフェースから呼ばれたかを判別する方法を見つけたので共有します。

元々見つけたコードは以下です。
https://github.com/bkht/STM32-HAL-DMA-Interrupt/blob/e94bcbc56e736500ef29bdfc01429665afa48c43/Src/main.c#L435