### PR TITLE
Visualize PFS sensor data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository will develop boards and firmware with the following features.
   ```
   # Set ROS_MASTER_URI to your PR2
   source ~/pr2_fingertip_ws/devel/setup.bash
-  rosrun pr2_fingertip_sensors parse_pfs.py
+  roslaunch pr2_fingertip_sensors pfs.launch
   ```
 
 - Subscribe sensor data
@@ -44,6 +44,12 @@ This repository will develop boards and firmware with the following features.
   rostopic echo /pfs/l_gripper/r_fingertip
   rostopic echo /pfs/r_gripper/l_fingertip
   rostopic echo /pfs/r_gripper/r_fingertip
+  ```
+
+- View sensor data with sample rosbag
+
+  ```
+  roslaunch pr2_fingertip_sensors sample_pfs.launch
   ```
 
 # Directories

--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -1,0 +1,554 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 728
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_bellow_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_laser_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        double_stereo_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_plate_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_tilt_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        high_def_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        high_def_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        imu_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_elbow_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_forearm_cam_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_forearm_cam_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_forearm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_forearm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_l_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_l_finger_tip_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_l_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_led_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_motor_accelerometer_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_motor_screw_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_motor_slider_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_palm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_r_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_r_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_tool_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_shoulder_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_shoulder_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_torso_lift_side_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_upper_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_upper_arm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_wrist_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_wrist_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        laser_tilt_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        laser_tilt_mount_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        narrow_stereo_l_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_l_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_r_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_r_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        projector_wg6802418_child_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        projector_wg6802418_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_elbow_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_forearm_cam_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_forearm_cam_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_forearm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_forearm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_l_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_l_finger_tip_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_l_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_led_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_motor_accelerometer_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_motor_screw_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_motor_slider_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_palm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_r_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_r_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_tool_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_shoulder_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_shoulder_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_torso_lift_side_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_upper_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_upper_arm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_wrist_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_wrist_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        sensor_mount_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        torso_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        torso_lift_motor_screw_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_l_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_l_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_r_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_r_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 5.094547748565674
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.22528541088104248
+        Y: 0.17093682289123535
+        Z: 0.341105580329895
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.3453982174396515
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.458585739135742
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1025
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000363fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004cc0000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1853
+  X: 67
+  Y: 27

--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -5,11 +5,12 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /Status1
-        - /TF1
-        - /TF1/Frames1
-      Splitter Ratio: 0.5
-    Tree Height: 728
+        - /L_Gripper_L_Finger1
+        - /L_Gripper_R_Finger1
+        - /R_Gripper_L_Finger1
+        - /R_Gripper_R_Finger1
+      Splitter Ratio: 0.5575540065765381
+    Tree Height: 1088
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -28,7 +29,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: A_Front
 Preferences:
   PromptSaveOnExit: true
 Toolbars:
@@ -475,767 +476,947 @@ Visualization Manager:
       Value: true
       Visual Enabled: true
     - Class: rviz/TF
-      Enabled: true
+      Enabled: false
       Frame Timeout: 15
       Frames:
-        All Enabled: false
-        base_bellow_link:
-          Value: false
-        base_footprint:
-          Value: false
-        base_laser_link:
-          Value: false
-        base_link:
-          Value: false
-        bl_caster_l_wheel_link:
-          Value: false
-        bl_caster_r_wheel_link:
-          Value: false
-        bl_caster_rotation_link:
-          Value: false
-        br_caster_l_wheel_link:
-          Value: false
-        br_caster_r_wheel_link:
-          Value: false
-        br_caster_rotation_link:
-          Value: false
-        double_stereo_link:
-          Value: false
-        fl_caster_l_wheel_link:
-          Value: false
-        fl_caster_r_wheel_link:
-          Value: false
-        fl_caster_rotation_link:
-          Value: false
-        fr_caster_l_wheel_link:
-          Value: false
-        fr_caster_r_wheel_link:
-          Value: false
-        fr_caster_rotation_link:
-          Value: false
-        head_pan_link:
-          Value: false
-        head_plate_frame:
-          Value: false
-        head_tilt_link:
-          Value: false
-        high_def_frame:
-          Value: false
-        high_def_optical_frame:
-          Value: false
-        imu_link:
-          Value: false
-        l_elbow_flex_link:
-          Value: false
-        l_forearm_cam_frame:
-          Value: false
-        l_forearm_cam_optical_frame:
-          Value: false
-        l_forearm_link:
-          Value: false
-        l_forearm_roll_link:
-          Value: false
-        l_gripper_l_finger_link:
-          Value: false
-        l_gripper_l_finger_tip_frame:
-          Value: false
-        l_gripper_l_finger_tip_link:
-          Value: false
-        l_gripper_l_fingertip_pfs_a:
-          Value: true
-        l_gripper_l_fingertip_pfs_a_0:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_1:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_2:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_3:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_4:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_5:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_6:
-          Value: false
-        l_gripper_l_fingertip_pfs_a_7:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_back:
-          Value: true
-        l_gripper_l_fingertip_pfs_b_back_0:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_back_1:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_back_2:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_back_3:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_left:
-          Value: true
-        l_gripper_l_fingertip_pfs_b_left_0:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_left_1:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_left_2:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_left_3:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_right:
-          Value: true
-        l_gripper_l_fingertip_pfs_b_right_0:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_right_1:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_right_2:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_right_3:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_top:
-          Value: true
-        l_gripper_l_fingertip_pfs_b_top_0:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_top_1:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_top_2:
-          Value: false
-        l_gripper_l_fingertip_pfs_b_top_3:
-          Value: false
-        l_gripper_led_frame:
-          Value: false
-        l_gripper_motor_accelerometer_link:
-          Value: false
-        l_gripper_motor_screw_link:
-          Value: false
-        l_gripper_motor_slider_link:
-          Value: false
-        l_gripper_palm_link:
-          Value: false
-        l_gripper_r_finger_link:
-          Value: false
-        l_gripper_r_finger_tip_link:
-          Value: false
-        l_gripper_r_finger_tip_link_flipped:
-          Value: false
-        l_gripper_r_fingertip_pfs_a:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_0:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_1:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_2:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_3:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_4:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_5:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_6:
-          Value: false
-        l_gripper_r_fingertip_pfs_a_7:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_back:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_back_0:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_back_1:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_back_2:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_back_3:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_left:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_left_0:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_left_1:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_left_2:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_left_3:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_right:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_right_0:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_right_1:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_right_2:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_right_3:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_top:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_top_0:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_top_1:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_top_2:
-          Value: false
-        l_gripper_r_fingertip_pfs_b_top_3:
-          Value: false
-        l_gripper_tool_frame:
-          Value: false
-        l_shoulder_lift_link:
-          Value: false
-        l_shoulder_pan_link:
-          Value: false
-        l_torso_lift_side_plate_link:
-          Value: false
-        l_upper_arm_link:
-          Value: false
-        l_upper_arm_roll_link:
-          Value: false
-        l_wrist_flex_link:
-          Value: false
-        l_wrist_roll_link:
-          Value: false
-        laser_tilt_link:
-          Value: false
-        laser_tilt_mount_link:
-          Value: false
-        narrow_stereo_l_stereo_camera_frame:
-          Value: false
-        narrow_stereo_l_stereo_camera_optical_frame:
-          Value: false
-        narrow_stereo_link:
-          Value: false
-        narrow_stereo_optical_frame:
-          Value: false
-        narrow_stereo_r_stereo_camera_frame:
-          Value: false
-        narrow_stereo_r_stereo_camera_optical_frame:
-          Value: false
-        projector_wg6802418_child_frame:
-          Value: false
-        projector_wg6802418_frame:
-          Value: false
-        r_elbow_flex_link:
-          Value: false
-        r_forearm_cam_frame:
-          Value: false
-        r_forearm_cam_optical_frame:
-          Value: false
-        r_forearm_link:
-          Value: false
-        r_forearm_roll_link:
-          Value: false
-        r_gripper_l_finger_link:
-          Value: false
-        r_gripper_l_finger_tip_frame:
-          Value: false
-        r_gripper_l_finger_tip_link:
-          Value: false
-        r_gripper_l_fingertip_pfs_a:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_0:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_1:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_2:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_3:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_4:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_5:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_6:
-          Value: false
-        r_gripper_l_fingertip_pfs_a_7:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_back:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_back_0:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_back_1:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_back_2:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_back_3:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_left:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_left_0:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_left_1:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_left_2:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_left_3:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_right:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_right_0:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_right_1:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_right_2:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_right_3:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_top:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_top_0:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_top_1:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_top_2:
-          Value: false
-        r_gripper_l_fingertip_pfs_b_top_3:
-          Value: false
-        r_gripper_led_frame:
-          Value: false
-        r_gripper_motor_accelerometer_link:
-          Value: false
-        r_gripper_motor_screw_link:
-          Value: false
-        r_gripper_motor_slider_link:
-          Value: false
-        r_gripper_palm_link:
-          Value: false
-        r_gripper_r_finger_link:
-          Value: false
-        r_gripper_r_finger_tip_link:
-          Value: false
-        r_gripper_r_finger_tip_link_flipped:
-          Value: false
-        r_gripper_r_fingertip_pfs_a:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_0:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_1:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_2:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_3:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_4:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_5:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_6:
-          Value: false
-        r_gripper_r_fingertip_pfs_a_7:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_back:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_back_0:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_back_1:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_back_2:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_back_3:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_left:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_left_0:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_left_1:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_left_2:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_left_3:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_right:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_right_0:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_right_1:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_right_2:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_right_3:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_top:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_top_0:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_top_1:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_top_2:
-          Value: false
-        r_gripper_r_fingertip_pfs_b_top_3:
-          Value: false
-        r_gripper_tool_frame:
-          Value: false
-        r_shoulder_lift_link:
-          Value: false
-        r_shoulder_pan_link:
-          Value: false
-        r_torso_lift_side_plate_link:
-          Value: false
-        r_upper_arm_link:
-          Value: false
-        r_upper_arm_roll_link:
-          Value: false
-        r_wrist_flex_link:
-          Value: false
-        r_wrist_roll_link:
-          Value: false
-        sensor_mount_link:
-          Value: false
-        torso_lift_link:
-          Value: false
-        torso_lift_motor_screw_link:
-          Value: false
-        wide_stereo_l_stereo_camera_frame:
-          Value: false
-        wide_stereo_l_stereo_camera_optical_frame:
-          Value: false
-        wide_stereo_link:
-          Value: false
-        wide_stereo_optical_frame:
-          Value: false
-        wide_stereo_r_stereo_camera_frame:
-          Value: false
-        wide_stereo_r_stereo_camera_optical_frame:
-          Value: false
-      Marker Scale: 0.30000001192092896
+        All Enabled: true
+      Marker Scale: 1
       Name: TF
       Show Arrows: true
       Show Axes: true
-      Show Names: false
+      Show Names: true
       Tree:
-        base_footprint:
-          base_link:
-            base_bellow_link:
-              {}
-            base_laser_link:
-              {}
-            bl_caster_rotation_link:
-              bl_caster_l_wheel_link:
-                {}
-              bl_caster_r_wheel_link:
-                {}
-            br_caster_rotation_link:
-              br_caster_l_wheel_link:
-                {}
-              br_caster_r_wheel_link:
-                {}
-            fl_caster_rotation_link:
-              fl_caster_l_wheel_link:
-                {}
-              fl_caster_r_wheel_link:
-                {}
-            fr_caster_rotation_link:
-              fr_caster_l_wheel_link:
-                {}
-              fr_caster_r_wheel_link:
-                {}
-            torso_lift_link:
-              head_pan_link:
-                head_tilt_link:
-                  head_plate_frame:
-                    projector_wg6802418_frame:
-                      projector_wg6802418_child_frame:
-                        {}
-                    sensor_mount_link:
-                      double_stereo_link:
-                        narrow_stereo_link:
-                          narrow_stereo_l_stereo_camera_frame:
-                            narrow_stereo_l_stereo_camera_optical_frame:
-                              {}
-                            narrow_stereo_r_stereo_camera_frame:
-                              narrow_stereo_r_stereo_camera_optical_frame:
-                                {}
-                          narrow_stereo_optical_frame:
-                            {}
-                        wide_stereo_link:
-                          wide_stereo_l_stereo_camera_frame:
-                            wide_stereo_l_stereo_camera_optical_frame:
-                              {}
-                            wide_stereo_r_stereo_camera_frame:
-                              wide_stereo_r_stereo_camera_optical_frame:
-                                {}
-                          wide_stereo_optical_frame:
-                            {}
-                      high_def_frame:
-                        high_def_optical_frame:
-                          {}
-              imu_link:
-                {}
-              l_shoulder_pan_link:
-                l_shoulder_lift_link:
-                  l_upper_arm_roll_link:
-                    l_upper_arm_link:
-                      l_elbow_flex_link:
-                        l_forearm_roll_link:
-                          l_forearm_cam_frame:
-                            l_forearm_cam_optical_frame:
-                              {}
-                          l_forearm_link:
-                            l_wrist_flex_link:
-                              l_wrist_roll_link:
-                                l_gripper_palm_link:
-                                  l_gripper_l_finger_link:
-                                    l_gripper_l_finger_tip_link:
-                                      l_gripper_l_fingertip_pfs_a:
-                                        l_gripper_l_fingertip_pfs_a_0:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_1:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_2:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_3:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_4:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_5:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_6:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_a_7:
-                                          {}
-                                      l_gripper_l_fingertip_pfs_b_back:
-                                        l_gripper_l_fingertip_pfs_b_back_0:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_back_1:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_back_2:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_back_3:
-                                          {}
-                                      l_gripper_l_fingertip_pfs_b_left:
-                                        l_gripper_l_fingertip_pfs_b_left_0:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_left_1:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_left_2:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_left_3:
-                                          {}
-                                      l_gripper_l_fingertip_pfs_b_right:
-                                        l_gripper_l_fingertip_pfs_b_right_0:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_right_1:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_right_2:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_right_3:
-                                          {}
-                                      l_gripper_l_fingertip_pfs_b_top:
-                                        l_gripper_l_fingertip_pfs_b_top_0:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_top_1:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_top_2:
-                                          {}
-                                        l_gripper_l_fingertip_pfs_b_top_3:
-                                          {}
-                                  l_gripper_led_frame:
-                                    {}
-                                  l_gripper_motor_accelerometer_link:
-                                    {}
-                                  l_gripper_motor_slider_link:
-                                    l_gripper_motor_screw_link:
-                                      {}
-                                  l_gripper_r_finger_link:
-                                    l_gripper_r_finger_tip_link:
-                                      l_gripper_l_finger_tip_frame:
-                                        {}
-                                      l_gripper_r_finger_tip_link_flipped:
-                                        l_gripper_r_fingertip_pfs_a:
-                                          l_gripper_r_fingertip_pfs_a_0:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_1:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_2:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_3:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_4:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_5:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_6:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_a_7:
-                                            {}
-                                        l_gripper_r_fingertip_pfs_b_back:
-                                          l_gripper_r_fingertip_pfs_b_back_0:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_back_1:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_back_2:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_back_3:
-                                            {}
-                                        l_gripper_r_fingertip_pfs_b_left:
-                                          l_gripper_r_fingertip_pfs_b_left_0:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_left_1:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_left_2:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_left_3:
-                                            {}
-                                        l_gripper_r_fingertip_pfs_b_right:
-                                          l_gripper_r_fingertip_pfs_b_right_0:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_right_1:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_right_2:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_right_3:
-                                            {}
-                                        l_gripper_r_fingertip_pfs_b_top:
-                                          l_gripper_r_fingertip_pfs_b_top_0:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_top_1:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_top_2:
-                                            {}
-                                          l_gripper_r_fingertip_pfs_b_top_3:
-                                            {}
-                                  l_gripper_tool_frame:
-                                    {}
-              l_torso_lift_side_plate_link:
-                {}
-              laser_tilt_mount_link:
-                laser_tilt_link:
-                  {}
-              r_shoulder_pan_link:
-                r_shoulder_lift_link:
-                  r_upper_arm_roll_link:
-                    r_upper_arm_link:
-                      r_elbow_flex_link:
-                        r_forearm_roll_link:
-                          r_forearm_cam_frame:
-                            r_forearm_cam_optical_frame:
-                              {}
-                          r_forearm_link:
-                            r_wrist_flex_link:
-                              r_wrist_roll_link:
-                                r_gripper_palm_link:
-                                  r_gripper_l_finger_link:
-                                    r_gripper_l_finger_tip_link:
-                                      r_gripper_l_fingertip_pfs_a:
-                                        r_gripper_l_fingertip_pfs_a_0:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_1:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_2:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_3:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_4:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_5:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_6:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_a_7:
-                                          {}
-                                      r_gripper_l_fingertip_pfs_b_back:
-                                        r_gripper_l_fingertip_pfs_b_back_0:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_back_1:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_back_2:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_back_3:
-                                          {}
-                                      r_gripper_l_fingertip_pfs_b_left:
-                                        r_gripper_l_fingertip_pfs_b_left_0:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_left_1:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_left_2:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_left_3:
-                                          {}
-                                      r_gripper_l_fingertip_pfs_b_right:
-                                        r_gripper_l_fingertip_pfs_b_right_0:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_right_1:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_right_2:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_right_3:
-                                          {}
-                                      r_gripper_l_fingertip_pfs_b_top:
-                                        r_gripper_l_fingertip_pfs_b_top_0:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_top_1:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_top_2:
-                                          {}
-                                        r_gripper_l_fingertip_pfs_b_top_3:
-                                          {}
-                                  r_gripper_led_frame:
-                                    {}
-                                  r_gripper_motor_accelerometer_link:
-                                    {}
-                                  r_gripper_motor_slider_link:
-                                    r_gripper_motor_screw_link:
-                                      {}
-                                  r_gripper_r_finger_link:
-                                    r_gripper_r_finger_tip_link:
-                                      r_gripper_l_finger_tip_frame:
-                                        {}
-                                      r_gripper_r_finger_tip_link_flipped:
-                                        r_gripper_r_fingertip_pfs_a:
-                                          r_gripper_r_fingertip_pfs_a_0:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_1:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_2:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_3:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_4:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_5:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_6:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_a_7:
-                                            {}
-                                        r_gripper_r_fingertip_pfs_b_back:
-                                          r_gripper_r_fingertip_pfs_b_back_0:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_back_1:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_back_2:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_back_3:
-                                            {}
-                                        r_gripper_r_fingertip_pfs_b_left:
-                                          r_gripper_r_fingertip_pfs_b_left_0:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_left_1:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_left_2:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_left_3:
-                                            {}
-                                        r_gripper_r_fingertip_pfs_b_right:
-                                          r_gripper_r_fingertip_pfs_b_right_0:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_right_1:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_right_2:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_right_3:
-                                            {}
-                                        r_gripper_r_fingertip_pfs_b_top:
-                                          r_gripper_r_fingertip_pfs_b_top_0:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_top_1:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_top_2:
-                                            {}
-                                          r_gripper_r_fingertip_pfs_b_top_3:
-                                            {}
-                                  r_gripper_tool_frame:
-                                    {}
-              r_torso_lift_side_plate_link:
-                {}
-            torso_lift_motor_screw_link:
-              {}
+        {}
       Update Interval: 0
-      Value: true
+      Value: false
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: A_Front
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Top
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Back
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Left
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Right
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+          Enabled: true
+          Name: ProximityCloud
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: A_Front
+              Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Top
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Back
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Left
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Right
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Wrench
+      Enabled: true
+      Name: L_Gripper_L_Finger
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: A_Front
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Top
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Back
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Left
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Right
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+          Enabled: true
+          Name: ProximityCloud
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: A_Front
+              Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Top
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Back
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Left
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Right
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Wrench
+      Enabled: true
+      Name: L_Gripper_R_Finger
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: A_Front
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Top
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Back
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Left
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Right
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+          Enabled: true
+          Name: ProximityCloud
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: A_Front
+              Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Top
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Back
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Left
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Right
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Wrench
+      Enabled: true
+      Name: R_Gripper_L_Finger
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: A_Front
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Top
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Back
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Left
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 138; 226; 52
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: B_Right
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 5
+              Size (m): 0.009999999776482582
+              Style: Points
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+          Enabled: true
+          Name: ProximityCloud
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: A_Front
+              Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Top
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Back
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Left
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+            - Alpha: 1
+              Arrow Width: 0.10000000149011612
+              Class: rviz/WrenchStamped
+              Enabled: true
+              Force Arrow Scale: 1
+              Force Color: 204; 51; 51
+              Hide Small Values: false
+              History Length: 1
+              Name: B_Right
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/force
+              Torque Arrow Scale: 1
+              Torque Color: 204; 204; 51
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Wrench
+      Enabled: true
+      Name: R_Gripper_R_Finger
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -1260,37 +1441,39 @@ Visualization Manager:
     - Class: rviz/PublishPoint
       Single click: true
       Topic: /clicked_point
+    - Class: jsk_rviz_plugin/CloseAll
+    - Class: jsk_rviz_plugin/OpenAll
   Value: true
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 1.8785362243652344
+      Distance: 3.1109416484832764
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.022203989326953888
-        Y: -0.06722698360681534
-        Z: 0.9194647073745728
+        X: -0.025779271498322487
+        Y: -0.0711732730269432
+        Z: 0.2643868327140808
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.7203978300094604
-      Target Frame: <Fixed Frame>
+      Pitch: 0.579797625541687
+      Target Frame: base_link
       Value: Orbit (rviz)
-      Yaw: 0.603567361831665
+      Yaw: 5.792049407958984
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1025
+  Height: 1385
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd00000004000000000000024c00000363fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004eb0000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001e3000004cbfc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000004cb000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004b0069006e00650063007400430061006d00650072006102000000830000013e0000026c000001bafb00000018004e006100720072006f007700430061006d00650072006100000002cb000000be0000000000000000000000010000010f000007cefc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000007ce000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000009bd0000003efc0100000002fb0000000800540069006d00650100000000000009bd000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000007d4000004cb00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -1299,6 +1482,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1853
+  Width: 2493
   X: 67
   Y: 27

--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -6,6 +6,8 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
+        - /TF1
+        - /TF1/Frames1
       Splitter Ratio: 0.5
     Tree Height: 728
   - Class: rviz/Selection
@@ -473,19 +475,761 @@ Visualization Manager:
       Value: true
       Visual Enabled: true
     - Class: rviz/TF
-      Enabled: false
+      Enabled: true
       Frame Timeout: 15
       Frames:
-        All Enabled: true
-      Marker Scale: 1
+        All Enabled: false
+        base_bellow_link:
+          Value: false
+        base_footprint:
+          Value: false
+        base_laser_link:
+          Value: false
+        base_link:
+          Value: false
+        bl_caster_l_wheel_link:
+          Value: false
+        bl_caster_r_wheel_link:
+          Value: false
+        bl_caster_rotation_link:
+          Value: false
+        br_caster_l_wheel_link:
+          Value: false
+        br_caster_r_wheel_link:
+          Value: false
+        br_caster_rotation_link:
+          Value: false
+        double_stereo_link:
+          Value: false
+        fl_caster_l_wheel_link:
+          Value: false
+        fl_caster_r_wheel_link:
+          Value: false
+        fl_caster_rotation_link:
+          Value: false
+        fr_caster_l_wheel_link:
+          Value: false
+        fr_caster_r_wheel_link:
+          Value: false
+        fr_caster_rotation_link:
+          Value: false
+        head_pan_link:
+          Value: false
+        head_plate_frame:
+          Value: false
+        head_tilt_link:
+          Value: false
+        high_def_frame:
+          Value: false
+        high_def_optical_frame:
+          Value: false
+        imu_link:
+          Value: false
+        l_elbow_flex_link:
+          Value: false
+        l_forearm_cam_frame:
+          Value: false
+        l_forearm_cam_optical_frame:
+          Value: false
+        l_forearm_link:
+          Value: false
+        l_forearm_roll_link:
+          Value: false
+        l_gripper_l_finger_link:
+          Value: false
+        l_gripper_l_finger_pfs_a:
+          Value: true
+        l_gripper_l_finger_pfs_a_0:
+          Value: false
+        l_gripper_l_finger_pfs_a_1:
+          Value: false
+        l_gripper_l_finger_pfs_a_2:
+          Value: false
+        l_gripper_l_finger_pfs_a_3:
+          Value: false
+        l_gripper_l_finger_pfs_a_4:
+          Value: false
+        l_gripper_l_finger_pfs_a_5:
+          Value: false
+        l_gripper_l_finger_pfs_a_6:
+          Value: false
+        l_gripper_l_finger_pfs_a_7:
+          Value: false
+        l_gripper_l_finger_pfs_b_back:
+          Value: true
+        l_gripper_l_finger_pfs_b_back_0:
+          Value: false
+        l_gripper_l_finger_pfs_b_back_1:
+          Value: false
+        l_gripper_l_finger_pfs_b_back_2:
+          Value: false
+        l_gripper_l_finger_pfs_b_back_3:
+          Value: false
+        l_gripper_l_finger_pfs_b_left:
+          Value: true
+        l_gripper_l_finger_pfs_b_left_0:
+          Value: false
+        l_gripper_l_finger_pfs_b_left_1:
+          Value: false
+        l_gripper_l_finger_pfs_b_left_2:
+          Value: false
+        l_gripper_l_finger_pfs_b_left_3:
+          Value: false
+        l_gripper_l_finger_pfs_b_right:
+          Value: true
+        l_gripper_l_finger_pfs_b_right_0:
+          Value: false
+        l_gripper_l_finger_pfs_b_right_1:
+          Value: false
+        l_gripper_l_finger_pfs_b_right_2:
+          Value: false
+        l_gripper_l_finger_pfs_b_right_3:
+          Value: false
+        l_gripper_l_finger_pfs_b_top:
+          Value: true
+        l_gripper_l_finger_pfs_b_top_0:
+          Value: false
+        l_gripper_l_finger_pfs_b_top_1:
+          Value: false
+        l_gripper_l_finger_pfs_b_top_2:
+          Value: false
+        l_gripper_l_finger_pfs_b_top_3:
+          Value: false
+        l_gripper_l_finger_tip_frame:
+          Value: false
+        l_gripper_l_finger_tip_link:
+          Value: false
+        l_gripper_led_frame:
+          Value: false
+        l_gripper_motor_accelerometer_link:
+          Value: false
+        l_gripper_motor_screw_link:
+          Value: false
+        l_gripper_motor_slider_link:
+          Value: false
+        l_gripper_palm_link:
+          Value: false
+        l_gripper_r_finger_link:
+          Value: false
+        l_gripper_r_finger_pfs_a:
+          Value: false
+        l_gripper_r_finger_pfs_a_0:
+          Value: false
+        l_gripper_r_finger_pfs_a_1:
+          Value: false
+        l_gripper_r_finger_pfs_a_2:
+          Value: false
+        l_gripper_r_finger_pfs_a_3:
+          Value: false
+        l_gripper_r_finger_pfs_a_4:
+          Value: false
+        l_gripper_r_finger_pfs_a_5:
+          Value: false
+        l_gripper_r_finger_pfs_a_6:
+          Value: false
+        l_gripper_r_finger_pfs_a_7:
+          Value: false
+        l_gripper_r_finger_pfs_b_back:
+          Value: false
+        l_gripper_r_finger_pfs_b_back_0:
+          Value: false
+        l_gripper_r_finger_pfs_b_back_1:
+          Value: false
+        l_gripper_r_finger_pfs_b_back_2:
+          Value: false
+        l_gripper_r_finger_pfs_b_back_3:
+          Value: false
+        l_gripper_r_finger_pfs_b_left:
+          Value: false
+        l_gripper_r_finger_pfs_b_left_0:
+          Value: false
+        l_gripper_r_finger_pfs_b_left_1:
+          Value: false
+        l_gripper_r_finger_pfs_b_left_2:
+          Value: false
+        l_gripper_r_finger_pfs_b_left_3:
+          Value: false
+        l_gripper_r_finger_pfs_b_right:
+          Value: false
+        l_gripper_r_finger_pfs_b_right_0:
+          Value: false
+        l_gripper_r_finger_pfs_b_right_1:
+          Value: false
+        l_gripper_r_finger_pfs_b_right_2:
+          Value: false
+        l_gripper_r_finger_pfs_b_right_3:
+          Value: false
+        l_gripper_r_finger_pfs_b_top:
+          Value: false
+        l_gripper_r_finger_pfs_b_top_0:
+          Value: false
+        l_gripper_r_finger_pfs_b_top_1:
+          Value: false
+        l_gripper_r_finger_pfs_b_top_2:
+          Value: false
+        l_gripper_r_finger_pfs_b_top_3:
+          Value: false
+        l_gripper_r_finger_tip_link:
+          Value: false
+        l_gripper_tool_frame:
+          Value: false
+        l_shoulder_lift_link:
+          Value: false
+        l_shoulder_pan_link:
+          Value: false
+        l_torso_lift_side_plate_link:
+          Value: false
+        l_upper_arm_link:
+          Value: false
+        l_upper_arm_roll_link:
+          Value: false
+        l_wrist_flex_link:
+          Value: false
+        l_wrist_roll_link:
+          Value: false
+        laser_tilt_link:
+          Value: false
+        laser_tilt_mount_link:
+          Value: false
+        narrow_stereo_l_stereo_camera_frame:
+          Value: false
+        narrow_stereo_l_stereo_camera_optical_frame:
+          Value: false
+        narrow_stereo_link:
+          Value: false
+        narrow_stereo_optical_frame:
+          Value: false
+        narrow_stereo_r_stereo_camera_frame:
+          Value: false
+        narrow_stereo_r_stereo_camera_optical_frame:
+          Value: false
+        projector_wg6802418_child_frame:
+          Value: false
+        projector_wg6802418_frame:
+          Value: false
+        r_elbow_flex_link:
+          Value: false
+        r_forearm_cam_frame:
+          Value: false
+        r_forearm_cam_optical_frame:
+          Value: false
+        r_forearm_link:
+          Value: false
+        r_forearm_roll_link:
+          Value: false
+        r_gripper_l_finger_link:
+          Value: false
+        r_gripper_l_finger_pfs_a:
+          Value: false
+        r_gripper_l_finger_pfs_a_0:
+          Value: false
+        r_gripper_l_finger_pfs_a_1:
+          Value: false
+        r_gripper_l_finger_pfs_a_2:
+          Value: false
+        r_gripper_l_finger_pfs_a_3:
+          Value: false
+        r_gripper_l_finger_pfs_a_4:
+          Value: false
+        r_gripper_l_finger_pfs_a_5:
+          Value: false
+        r_gripper_l_finger_pfs_a_6:
+          Value: false
+        r_gripper_l_finger_pfs_a_7:
+          Value: false
+        r_gripper_l_finger_pfs_b_back:
+          Value: false
+        r_gripper_l_finger_pfs_b_back_0:
+          Value: false
+        r_gripper_l_finger_pfs_b_back_1:
+          Value: false
+        r_gripper_l_finger_pfs_b_back_2:
+          Value: false
+        r_gripper_l_finger_pfs_b_back_3:
+          Value: false
+        r_gripper_l_finger_pfs_b_left:
+          Value: false
+        r_gripper_l_finger_pfs_b_left_0:
+          Value: false
+        r_gripper_l_finger_pfs_b_left_1:
+          Value: false
+        r_gripper_l_finger_pfs_b_left_2:
+          Value: false
+        r_gripper_l_finger_pfs_b_left_3:
+          Value: false
+        r_gripper_l_finger_pfs_b_right:
+          Value: false
+        r_gripper_l_finger_pfs_b_right_0:
+          Value: false
+        r_gripper_l_finger_pfs_b_right_1:
+          Value: false
+        r_gripper_l_finger_pfs_b_right_2:
+          Value: false
+        r_gripper_l_finger_pfs_b_right_3:
+          Value: false
+        r_gripper_l_finger_pfs_b_top:
+          Value: false
+        r_gripper_l_finger_pfs_b_top_0:
+          Value: false
+        r_gripper_l_finger_pfs_b_top_1:
+          Value: false
+        r_gripper_l_finger_pfs_b_top_2:
+          Value: false
+        r_gripper_l_finger_pfs_b_top_3:
+          Value: false
+        r_gripper_l_finger_tip_frame:
+          Value: false
+        r_gripper_l_finger_tip_link:
+          Value: false
+        r_gripper_led_frame:
+          Value: false
+        r_gripper_motor_accelerometer_link:
+          Value: false
+        r_gripper_motor_screw_link:
+          Value: false
+        r_gripper_motor_slider_link:
+          Value: false
+        r_gripper_palm_link:
+          Value: false
+        r_gripper_r_finger_link:
+          Value: false
+        r_gripper_r_finger_pfs_a:
+          Value: false
+        r_gripper_r_finger_pfs_a_0:
+          Value: false
+        r_gripper_r_finger_pfs_a_1:
+          Value: false
+        r_gripper_r_finger_pfs_a_2:
+          Value: false
+        r_gripper_r_finger_pfs_a_3:
+          Value: false
+        r_gripper_r_finger_pfs_a_4:
+          Value: false
+        r_gripper_r_finger_pfs_a_5:
+          Value: false
+        r_gripper_r_finger_pfs_a_6:
+          Value: false
+        r_gripper_r_finger_pfs_a_7:
+          Value: false
+        r_gripper_r_finger_pfs_b_back:
+          Value: false
+        r_gripper_r_finger_pfs_b_back_0:
+          Value: false
+        r_gripper_r_finger_pfs_b_back_1:
+          Value: false
+        r_gripper_r_finger_pfs_b_back_2:
+          Value: false
+        r_gripper_r_finger_pfs_b_back_3:
+          Value: false
+        r_gripper_r_finger_pfs_b_left:
+          Value: false
+        r_gripper_r_finger_pfs_b_left_0:
+          Value: false
+        r_gripper_r_finger_pfs_b_left_1:
+          Value: false
+        r_gripper_r_finger_pfs_b_left_2:
+          Value: false
+        r_gripper_r_finger_pfs_b_left_3:
+          Value: false
+        r_gripper_r_finger_pfs_b_right:
+          Value: false
+        r_gripper_r_finger_pfs_b_right_0:
+          Value: false
+        r_gripper_r_finger_pfs_b_right_1:
+          Value: false
+        r_gripper_r_finger_pfs_b_right_2:
+          Value: false
+        r_gripper_r_finger_pfs_b_right_3:
+          Value: false
+        r_gripper_r_finger_pfs_b_top:
+          Value: false
+        r_gripper_r_finger_pfs_b_top_0:
+          Value: false
+        r_gripper_r_finger_pfs_b_top_1:
+          Value: false
+        r_gripper_r_finger_pfs_b_top_2:
+          Value: false
+        r_gripper_r_finger_pfs_b_top_3:
+          Value: false
+        r_gripper_r_finger_tip_link:
+          Value: false
+        r_gripper_tool_frame:
+          Value: false
+        r_shoulder_lift_link:
+          Value: false
+        r_shoulder_pan_link:
+          Value: false
+        r_torso_lift_side_plate_link:
+          Value: false
+        r_upper_arm_link:
+          Value: false
+        r_upper_arm_roll_link:
+          Value: false
+        r_wrist_flex_link:
+          Value: false
+        r_wrist_roll_link:
+          Value: false
+        sensor_mount_link:
+          Value: false
+        torso_lift_link:
+          Value: false
+        torso_lift_motor_screw_link:
+          Value: false
+        wide_stereo_l_stereo_camera_frame:
+          Value: false
+        wide_stereo_l_stereo_camera_optical_frame:
+          Value: false
+        wide_stereo_link:
+          Value: false
+        wide_stereo_optical_frame:
+          Value: false
+        wide_stereo_r_stereo_camera_frame:
+          Value: false
+        wide_stereo_r_stereo_camera_optical_frame:
+          Value: false
+      Marker Scale: 0.30000001192092896
       Name: TF
       Show Arrows: true
       Show Axes: true
-      Show Names: true
+      Show Names: false
       Tree:
-        {}
+        base_footprint:
+          base_link:
+            base_bellow_link:
+              {}
+            base_laser_link:
+              {}
+            bl_caster_rotation_link:
+              bl_caster_l_wheel_link:
+                {}
+              bl_caster_r_wheel_link:
+                {}
+            br_caster_rotation_link:
+              br_caster_l_wheel_link:
+                {}
+              br_caster_r_wheel_link:
+                {}
+            fl_caster_rotation_link:
+              fl_caster_l_wheel_link:
+                {}
+              fl_caster_r_wheel_link:
+                {}
+            fr_caster_rotation_link:
+              fr_caster_l_wheel_link:
+                {}
+              fr_caster_r_wheel_link:
+                {}
+            torso_lift_link:
+              head_pan_link:
+                head_tilt_link:
+                  head_plate_frame:
+                    projector_wg6802418_frame:
+                      projector_wg6802418_child_frame:
+                        {}
+                    sensor_mount_link:
+                      double_stereo_link:
+                        narrow_stereo_link:
+                          narrow_stereo_l_stereo_camera_frame:
+                            narrow_stereo_l_stereo_camera_optical_frame:
+                              {}
+                            narrow_stereo_r_stereo_camera_frame:
+                              narrow_stereo_r_stereo_camera_optical_frame:
+                                {}
+                          narrow_stereo_optical_frame:
+                            {}
+                        wide_stereo_link:
+                          wide_stereo_l_stereo_camera_frame:
+                            wide_stereo_l_stereo_camera_optical_frame:
+                              {}
+                            wide_stereo_r_stereo_camera_frame:
+                              wide_stereo_r_stereo_camera_optical_frame:
+                                {}
+                          wide_stereo_optical_frame:
+                            {}
+                      high_def_frame:
+                        high_def_optical_frame:
+                          {}
+              imu_link:
+                {}
+              l_shoulder_pan_link:
+                l_shoulder_lift_link:
+                  l_upper_arm_roll_link:
+                    l_upper_arm_link:
+                      l_elbow_flex_link:
+                        l_forearm_roll_link:
+                          l_forearm_cam_frame:
+                            l_forearm_cam_optical_frame:
+                              {}
+                          l_forearm_link:
+                            l_wrist_flex_link:
+                              l_wrist_roll_link:
+                                l_gripper_palm_link:
+                                  l_gripper_l_finger_link:
+                                    l_gripper_l_finger_tip_link:
+                                      l_gripper_l_finger_pfs_a:
+                                        l_gripper_l_finger_pfs_a_0:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_1:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_2:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_3:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_4:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_5:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_6:
+                                          {}
+                                        l_gripper_l_finger_pfs_a_7:
+                                          {}
+                                      l_gripper_l_finger_pfs_b_back:
+                                        l_gripper_l_finger_pfs_b_back_0:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_back_1:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_back_2:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_back_3:
+                                          {}
+                                      l_gripper_l_finger_pfs_b_left:
+                                        l_gripper_l_finger_pfs_b_left_0:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_left_1:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_left_2:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_left_3:
+                                          {}
+                                      l_gripper_l_finger_pfs_b_right:
+                                        l_gripper_l_finger_pfs_b_right_0:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_right_1:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_right_2:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_right_3:
+                                          {}
+                                      l_gripper_l_finger_pfs_b_top:
+                                        l_gripper_l_finger_pfs_b_top_0:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_top_1:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_top_2:
+                                          {}
+                                        l_gripper_l_finger_pfs_b_top_3:
+                                          {}
+                                  l_gripper_led_frame:
+                                    {}
+                                  l_gripper_motor_accelerometer_link:
+                                    {}
+                                  l_gripper_motor_slider_link:
+                                    l_gripper_motor_screw_link:
+                                      {}
+                                  l_gripper_r_finger_link:
+                                    l_gripper_r_finger_tip_link:
+                                      l_gripper_l_finger_tip_frame:
+                                        {}
+                                      l_gripper_r_finger_pfs_a:
+                                        l_gripper_r_finger_pfs_a_0:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_1:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_2:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_3:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_4:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_5:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_6:
+                                          {}
+                                        l_gripper_r_finger_pfs_a_7:
+                                          {}
+                                      l_gripper_r_finger_pfs_b_back:
+                                        l_gripper_r_finger_pfs_b_back_0:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_back_1:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_back_2:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_back_3:
+                                          {}
+                                      l_gripper_r_finger_pfs_b_left:
+                                        l_gripper_r_finger_pfs_b_left_0:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_left_1:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_left_2:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_left_3:
+                                          {}
+                                      l_gripper_r_finger_pfs_b_right:
+                                        l_gripper_r_finger_pfs_b_right_0:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_right_1:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_right_2:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_right_3:
+                                          {}
+                                      l_gripper_r_finger_pfs_b_top:
+                                        l_gripper_r_finger_pfs_b_top_0:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_top_1:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_top_2:
+                                          {}
+                                        l_gripper_r_finger_pfs_b_top_3:
+                                          {}
+                                  l_gripper_tool_frame:
+                                    {}
+              l_torso_lift_side_plate_link:
+                {}
+              laser_tilt_mount_link:
+                laser_tilt_link:
+                  {}
+              r_shoulder_pan_link:
+                r_shoulder_lift_link:
+                  r_upper_arm_roll_link:
+                    r_upper_arm_link:
+                      r_elbow_flex_link:
+                        r_forearm_roll_link:
+                          r_forearm_cam_frame:
+                            r_forearm_cam_optical_frame:
+                              {}
+                          r_forearm_link:
+                            r_wrist_flex_link:
+                              r_wrist_roll_link:
+                                r_gripper_palm_link:
+                                  r_gripper_l_finger_link:
+                                    r_gripper_l_finger_tip_link:
+                                      r_gripper_l_finger_pfs_a:
+                                        r_gripper_l_finger_pfs_a_0:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_1:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_2:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_3:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_4:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_5:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_6:
+                                          {}
+                                        r_gripper_l_finger_pfs_a_7:
+                                          {}
+                                      r_gripper_l_finger_pfs_b_back:
+                                        r_gripper_l_finger_pfs_b_back_0:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_back_1:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_back_2:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_back_3:
+                                          {}
+                                      r_gripper_l_finger_pfs_b_left:
+                                        r_gripper_l_finger_pfs_b_left_0:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_left_1:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_left_2:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_left_3:
+                                          {}
+                                      r_gripper_l_finger_pfs_b_right:
+                                        r_gripper_l_finger_pfs_b_right_0:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_right_1:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_right_2:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_right_3:
+                                          {}
+                                      r_gripper_l_finger_pfs_b_top:
+                                        r_gripper_l_finger_pfs_b_top_0:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_top_1:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_top_2:
+                                          {}
+                                        r_gripper_l_finger_pfs_b_top_3:
+                                          {}
+                                  r_gripper_led_frame:
+                                    {}
+                                  r_gripper_motor_accelerometer_link:
+                                    {}
+                                  r_gripper_motor_slider_link:
+                                    r_gripper_motor_screw_link:
+                                      {}
+                                  r_gripper_r_finger_link:
+                                    r_gripper_r_finger_tip_link:
+                                      r_gripper_l_finger_tip_frame:
+                                        {}
+                                      r_gripper_r_finger_pfs_a:
+                                        r_gripper_r_finger_pfs_a_0:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_1:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_2:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_3:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_4:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_5:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_6:
+                                          {}
+                                        r_gripper_r_finger_pfs_a_7:
+                                          {}
+                                      r_gripper_r_finger_pfs_b_back:
+                                        r_gripper_r_finger_pfs_b_back_0:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_back_1:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_back_2:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_back_3:
+                                          {}
+                                      r_gripper_r_finger_pfs_b_left:
+                                        r_gripper_r_finger_pfs_b_left_0:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_left_1:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_left_2:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_left_3:
+                                          {}
+                                      r_gripper_r_finger_pfs_b_right:
+                                        r_gripper_r_finger_pfs_b_right_0:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_right_1:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_right_2:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_right_3:
+                                          {}
+                                      r_gripper_r_finger_pfs_b_top:
+                                        r_gripper_r_finger_pfs_b_top_0:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_top_1:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_top_2:
+                                          {}
+                                        r_gripper_r_finger_pfs_b_top_3:
+                                          {}
+                                  r_gripper_tool_frame:
+                                    {}
+              r_torso_lift_side_plate_link:
+                {}
+            torso_lift_motor_screw_link:
+              {}
       Update Interval: 0
-      Value: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -514,33 +1258,33 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 5.094547748565674
+      Distance: 1.8785362243652344
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.22528541088104248
-        Y: 0.17093682289123535
-        Z: 0.341105580329895
+        X: 0.022203989326953888
+        Y: -0.06722698360681534
+        Z: 0.9194647073745728
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.3453982174396515
+      Pitch: 0.7203978300094604
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 5.458585739135742
+      Yaw: 0.603567361831665
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
   Height: 1025
   Hide Left Dock: false
-  Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000015600000363fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004cc0000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000024c00000363fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004eb0000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -548,7 +1292,7 @@ Window Geometry:
   Tool Properties:
     collapsed: false
   Views:
-    collapsed: false
+    collapsed: true
   Width: 1853
   X: 67
   Y: 27

--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -719,6 +719,15 @@ Visualization Manager:
               Value: true
           Enabled: true
           Name: Wrench
+        - Alpha: 1
+          Class: rviz_plugin_tutorials/Imu
+          Color: 204; 51; 204
+          Enabled: true
+          History Length: 1
+          Name: Imu
+          Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/imu
+          Unreliable: false
+          Value: true
       Enabled: true
       Name: L_Gripper_L_Finger
     - Class: rviz/Group
@@ -951,6 +960,15 @@ Visualization Manager:
               Value: true
           Enabled: true
           Name: Wrench
+        - Alpha: 1
+          Class: rviz_plugin_tutorials/Imu
+          Color: 204; 51; 204
+          Enabled: true
+          History Length: 1
+          Name: Imu
+          Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/imu
+          Unreliable: false
+          Value: true
       Enabled: true
       Name: L_Gripper_R_Finger
     - Class: rviz/Group
@@ -1183,6 +1201,15 @@ Visualization Manager:
               Value: true
           Enabled: true
           Name: Wrench
+        - Alpha: 1
+          Class: rviz_plugin_tutorials/Imu
+          Color: 204; 51; 204
+          Enabled: true
+          History Length: 1
+          Name: Imu
+          Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/imu
+          Unreliable: false
+          Value: true
       Enabled: true
       Name: R_Gripper_L_Finger
     - Class: rviz/Group
@@ -1415,6 +1442,15 @@ Visualization Manager:
               Value: true
           Enabled: true
           Name: Wrench
+        - Alpha: 1
+          Class: rviz_plugin_tutorials/Imu
+          Color: 204; 51; 204
+          Enabled: true
+          History Length: 1
+          Name: Imu
+          Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/imu
+          Unreliable: false
+          Value: true
       Enabled: true
       Name: R_Gripper_R_Finger
   Enabled: true
@@ -1462,10 +1498,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.579797625541687
+      Pitch: 0.3347975015640259
       Target Frame: base_link
       Value: Orbit (rviz)
-      Yaw: 5.792049407958984
+      Yaw: 5.557054042816162
     Saved: ~
 Window Geometry:
   Displays:

--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -537,67 +537,67 @@ Visualization Manager:
           Value: false
         l_gripper_l_finger_link:
           Value: false
-        l_gripper_l_finger_pfs_a:
-          Value: true
-        l_gripper_l_finger_pfs_a_0:
-          Value: false
-        l_gripper_l_finger_pfs_a_1:
-          Value: false
-        l_gripper_l_finger_pfs_a_2:
-          Value: false
-        l_gripper_l_finger_pfs_a_3:
-          Value: false
-        l_gripper_l_finger_pfs_a_4:
-          Value: false
-        l_gripper_l_finger_pfs_a_5:
-          Value: false
-        l_gripper_l_finger_pfs_a_6:
-          Value: false
-        l_gripper_l_finger_pfs_a_7:
-          Value: false
-        l_gripper_l_finger_pfs_b_back:
-          Value: true
-        l_gripper_l_finger_pfs_b_back_0:
-          Value: false
-        l_gripper_l_finger_pfs_b_back_1:
-          Value: false
-        l_gripper_l_finger_pfs_b_back_2:
-          Value: false
-        l_gripper_l_finger_pfs_b_back_3:
-          Value: false
-        l_gripper_l_finger_pfs_b_left:
-          Value: true
-        l_gripper_l_finger_pfs_b_left_0:
-          Value: false
-        l_gripper_l_finger_pfs_b_left_1:
-          Value: false
-        l_gripper_l_finger_pfs_b_left_2:
-          Value: false
-        l_gripper_l_finger_pfs_b_left_3:
-          Value: false
-        l_gripper_l_finger_pfs_b_right:
-          Value: true
-        l_gripper_l_finger_pfs_b_right_0:
-          Value: false
-        l_gripper_l_finger_pfs_b_right_1:
-          Value: false
-        l_gripper_l_finger_pfs_b_right_2:
-          Value: false
-        l_gripper_l_finger_pfs_b_right_3:
-          Value: false
-        l_gripper_l_finger_pfs_b_top:
-          Value: true
-        l_gripper_l_finger_pfs_b_top_0:
-          Value: false
-        l_gripper_l_finger_pfs_b_top_1:
-          Value: false
-        l_gripper_l_finger_pfs_b_top_2:
-          Value: false
-        l_gripper_l_finger_pfs_b_top_3:
-          Value: false
         l_gripper_l_finger_tip_frame:
           Value: false
         l_gripper_l_finger_tip_link:
+          Value: false
+        l_gripper_l_fingertip_pfs_a:
+          Value: true
+        l_gripper_l_fingertip_pfs_a_0:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_1:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_2:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_3:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_4:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_5:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_6:
+          Value: false
+        l_gripper_l_fingertip_pfs_a_7:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_back:
+          Value: true
+        l_gripper_l_fingertip_pfs_b_back_0:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_back_1:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_back_2:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_back_3:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_left:
+          Value: true
+        l_gripper_l_fingertip_pfs_b_left_0:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_left_1:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_left_2:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_left_3:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_right:
+          Value: true
+        l_gripper_l_fingertip_pfs_b_right_0:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_right_1:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_right_2:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_right_3:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_top:
+          Value: true
+        l_gripper_l_fingertip_pfs_b_top_0:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_top_1:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_top_2:
+          Value: false
+        l_gripper_l_fingertip_pfs_b_top_3:
           Value: false
         l_gripper_led_frame:
           Value: false
@@ -611,65 +611,67 @@ Visualization Manager:
           Value: false
         l_gripper_r_finger_link:
           Value: false
-        l_gripper_r_finger_pfs_a:
-          Value: false
-        l_gripper_r_finger_pfs_a_0:
-          Value: false
-        l_gripper_r_finger_pfs_a_1:
-          Value: false
-        l_gripper_r_finger_pfs_a_2:
-          Value: false
-        l_gripper_r_finger_pfs_a_3:
-          Value: false
-        l_gripper_r_finger_pfs_a_4:
-          Value: false
-        l_gripper_r_finger_pfs_a_5:
-          Value: false
-        l_gripper_r_finger_pfs_a_6:
-          Value: false
-        l_gripper_r_finger_pfs_a_7:
-          Value: false
-        l_gripper_r_finger_pfs_b_back:
-          Value: false
-        l_gripper_r_finger_pfs_b_back_0:
-          Value: false
-        l_gripper_r_finger_pfs_b_back_1:
-          Value: false
-        l_gripper_r_finger_pfs_b_back_2:
-          Value: false
-        l_gripper_r_finger_pfs_b_back_3:
-          Value: false
-        l_gripper_r_finger_pfs_b_left:
-          Value: false
-        l_gripper_r_finger_pfs_b_left_0:
-          Value: false
-        l_gripper_r_finger_pfs_b_left_1:
-          Value: false
-        l_gripper_r_finger_pfs_b_left_2:
-          Value: false
-        l_gripper_r_finger_pfs_b_left_3:
-          Value: false
-        l_gripper_r_finger_pfs_b_right:
-          Value: false
-        l_gripper_r_finger_pfs_b_right_0:
-          Value: false
-        l_gripper_r_finger_pfs_b_right_1:
-          Value: false
-        l_gripper_r_finger_pfs_b_right_2:
-          Value: false
-        l_gripper_r_finger_pfs_b_right_3:
-          Value: false
-        l_gripper_r_finger_pfs_b_top:
-          Value: false
-        l_gripper_r_finger_pfs_b_top_0:
-          Value: false
-        l_gripper_r_finger_pfs_b_top_1:
-          Value: false
-        l_gripper_r_finger_pfs_b_top_2:
-          Value: false
-        l_gripper_r_finger_pfs_b_top_3:
-          Value: false
         l_gripper_r_finger_tip_link:
+          Value: false
+        l_gripper_r_finger_tip_link_flipped:
+          Value: false
+        l_gripper_r_fingertip_pfs_a:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_0:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_1:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_2:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_3:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_4:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_5:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_6:
+          Value: false
+        l_gripper_r_fingertip_pfs_a_7:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_back:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_back_0:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_back_1:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_back_2:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_back_3:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_left:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_left_0:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_left_1:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_left_2:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_left_3:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_right:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_right_0:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_right_1:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_right_2:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_right_3:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_top:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_top_0:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_top_1:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_top_2:
+          Value: false
+        l_gripper_r_fingertip_pfs_b_top_3:
           Value: false
         l_gripper_tool_frame:
           Value: false
@@ -719,67 +721,67 @@ Visualization Manager:
           Value: false
         r_gripper_l_finger_link:
           Value: false
-        r_gripper_l_finger_pfs_a:
-          Value: false
-        r_gripper_l_finger_pfs_a_0:
-          Value: false
-        r_gripper_l_finger_pfs_a_1:
-          Value: false
-        r_gripper_l_finger_pfs_a_2:
-          Value: false
-        r_gripper_l_finger_pfs_a_3:
-          Value: false
-        r_gripper_l_finger_pfs_a_4:
-          Value: false
-        r_gripper_l_finger_pfs_a_5:
-          Value: false
-        r_gripper_l_finger_pfs_a_6:
-          Value: false
-        r_gripper_l_finger_pfs_a_7:
-          Value: false
-        r_gripper_l_finger_pfs_b_back:
-          Value: false
-        r_gripper_l_finger_pfs_b_back_0:
-          Value: false
-        r_gripper_l_finger_pfs_b_back_1:
-          Value: false
-        r_gripper_l_finger_pfs_b_back_2:
-          Value: false
-        r_gripper_l_finger_pfs_b_back_3:
-          Value: false
-        r_gripper_l_finger_pfs_b_left:
-          Value: false
-        r_gripper_l_finger_pfs_b_left_0:
-          Value: false
-        r_gripper_l_finger_pfs_b_left_1:
-          Value: false
-        r_gripper_l_finger_pfs_b_left_2:
-          Value: false
-        r_gripper_l_finger_pfs_b_left_3:
-          Value: false
-        r_gripper_l_finger_pfs_b_right:
-          Value: false
-        r_gripper_l_finger_pfs_b_right_0:
-          Value: false
-        r_gripper_l_finger_pfs_b_right_1:
-          Value: false
-        r_gripper_l_finger_pfs_b_right_2:
-          Value: false
-        r_gripper_l_finger_pfs_b_right_3:
-          Value: false
-        r_gripper_l_finger_pfs_b_top:
-          Value: false
-        r_gripper_l_finger_pfs_b_top_0:
-          Value: false
-        r_gripper_l_finger_pfs_b_top_1:
-          Value: false
-        r_gripper_l_finger_pfs_b_top_2:
-          Value: false
-        r_gripper_l_finger_pfs_b_top_3:
-          Value: false
         r_gripper_l_finger_tip_frame:
           Value: false
         r_gripper_l_finger_tip_link:
+          Value: false
+        r_gripper_l_fingertip_pfs_a:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_0:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_1:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_2:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_3:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_4:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_5:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_6:
+          Value: false
+        r_gripper_l_fingertip_pfs_a_7:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_back:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_back_0:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_back_1:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_back_2:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_back_3:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_left:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_left_0:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_left_1:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_left_2:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_left_3:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_right:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_right_0:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_right_1:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_right_2:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_right_3:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_top:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_top_0:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_top_1:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_top_2:
+          Value: false
+        r_gripper_l_fingertip_pfs_b_top_3:
           Value: false
         r_gripper_led_frame:
           Value: false
@@ -793,65 +795,67 @@ Visualization Manager:
           Value: false
         r_gripper_r_finger_link:
           Value: false
-        r_gripper_r_finger_pfs_a:
-          Value: false
-        r_gripper_r_finger_pfs_a_0:
-          Value: false
-        r_gripper_r_finger_pfs_a_1:
-          Value: false
-        r_gripper_r_finger_pfs_a_2:
-          Value: false
-        r_gripper_r_finger_pfs_a_3:
-          Value: false
-        r_gripper_r_finger_pfs_a_4:
-          Value: false
-        r_gripper_r_finger_pfs_a_5:
-          Value: false
-        r_gripper_r_finger_pfs_a_6:
-          Value: false
-        r_gripper_r_finger_pfs_a_7:
-          Value: false
-        r_gripper_r_finger_pfs_b_back:
-          Value: false
-        r_gripper_r_finger_pfs_b_back_0:
-          Value: false
-        r_gripper_r_finger_pfs_b_back_1:
-          Value: false
-        r_gripper_r_finger_pfs_b_back_2:
-          Value: false
-        r_gripper_r_finger_pfs_b_back_3:
-          Value: false
-        r_gripper_r_finger_pfs_b_left:
-          Value: false
-        r_gripper_r_finger_pfs_b_left_0:
-          Value: false
-        r_gripper_r_finger_pfs_b_left_1:
-          Value: false
-        r_gripper_r_finger_pfs_b_left_2:
-          Value: false
-        r_gripper_r_finger_pfs_b_left_3:
-          Value: false
-        r_gripper_r_finger_pfs_b_right:
-          Value: false
-        r_gripper_r_finger_pfs_b_right_0:
-          Value: false
-        r_gripper_r_finger_pfs_b_right_1:
-          Value: false
-        r_gripper_r_finger_pfs_b_right_2:
-          Value: false
-        r_gripper_r_finger_pfs_b_right_3:
-          Value: false
-        r_gripper_r_finger_pfs_b_top:
-          Value: false
-        r_gripper_r_finger_pfs_b_top_0:
-          Value: false
-        r_gripper_r_finger_pfs_b_top_1:
-          Value: false
-        r_gripper_r_finger_pfs_b_top_2:
-          Value: false
-        r_gripper_r_finger_pfs_b_top_3:
-          Value: false
         r_gripper_r_finger_tip_link:
+          Value: false
+        r_gripper_r_finger_tip_link_flipped:
+          Value: false
+        r_gripper_r_fingertip_pfs_a:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_0:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_1:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_2:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_3:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_4:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_5:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_6:
+          Value: false
+        r_gripper_r_fingertip_pfs_a_7:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_back:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_back_0:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_back_1:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_back_2:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_back_3:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_left:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_left_0:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_left_1:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_left_2:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_left_3:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_right:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_right_0:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_right_1:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_right_2:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_right_3:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_top:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_top_0:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_top_1:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_top_2:
+          Value: false
+        r_gripper_r_fingertip_pfs_b_top_3:
           Value: false
         r_gripper_tool_frame:
           Value: false
@@ -966,58 +970,58 @@ Visualization Manager:
                                 l_gripper_palm_link:
                                   l_gripper_l_finger_link:
                                     l_gripper_l_finger_tip_link:
-                                      l_gripper_l_finger_pfs_a:
-                                        l_gripper_l_finger_pfs_a_0:
+                                      l_gripper_l_fingertip_pfs_a:
+                                        l_gripper_l_fingertip_pfs_a_0:
                                           {}
-                                        l_gripper_l_finger_pfs_a_1:
+                                        l_gripper_l_fingertip_pfs_a_1:
                                           {}
-                                        l_gripper_l_finger_pfs_a_2:
+                                        l_gripper_l_fingertip_pfs_a_2:
                                           {}
-                                        l_gripper_l_finger_pfs_a_3:
+                                        l_gripper_l_fingertip_pfs_a_3:
                                           {}
-                                        l_gripper_l_finger_pfs_a_4:
+                                        l_gripper_l_fingertip_pfs_a_4:
                                           {}
-                                        l_gripper_l_finger_pfs_a_5:
+                                        l_gripper_l_fingertip_pfs_a_5:
                                           {}
-                                        l_gripper_l_finger_pfs_a_6:
+                                        l_gripper_l_fingertip_pfs_a_6:
                                           {}
-                                        l_gripper_l_finger_pfs_a_7:
+                                        l_gripper_l_fingertip_pfs_a_7:
                                           {}
-                                      l_gripper_l_finger_pfs_b_back:
-                                        l_gripper_l_finger_pfs_b_back_0:
+                                      l_gripper_l_fingertip_pfs_b_back:
+                                        l_gripper_l_fingertip_pfs_b_back_0:
                                           {}
-                                        l_gripper_l_finger_pfs_b_back_1:
+                                        l_gripper_l_fingertip_pfs_b_back_1:
                                           {}
-                                        l_gripper_l_finger_pfs_b_back_2:
+                                        l_gripper_l_fingertip_pfs_b_back_2:
                                           {}
-                                        l_gripper_l_finger_pfs_b_back_3:
+                                        l_gripper_l_fingertip_pfs_b_back_3:
                                           {}
-                                      l_gripper_l_finger_pfs_b_left:
-                                        l_gripper_l_finger_pfs_b_left_0:
+                                      l_gripper_l_fingertip_pfs_b_left:
+                                        l_gripper_l_fingertip_pfs_b_left_0:
                                           {}
-                                        l_gripper_l_finger_pfs_b_left_1:
+                                        l_gripper_l_fingertip_pfs_b_left_1:
                                           {}
-                                        l_gripper_l_finger_pfs_b_left_2:
+                                        l_gripper_l_fingertip_pfs_b_left_2:
                                           {}
-                                        l_gripper_l_finger_pfs_b_left_3:
+                                        l_gripper_l_fingertip_pfs_b_left_3:
                                           {}
-                                      l_gripper_l_finger_pfs_b_right:
-                                        l_gripper_l_finger_pfs_b_right_0:
+                                      l_gripper_l_fingertip_pfs_b_right:
+                                        l_gripper_l_fingertip_pfs_b_right_0:
                                           {}
-                                        l_gripper_l_finger_pfs_b_right_1:
+                                        l_gripper_l_fingertip_pfs_b_right_1:
                                           {}
-                                        l_gripper_l_finger_pfs_b_right_2:
+                                        l_gripper_l_fingertip_pfs_b_right_2:
                                           {}
-                                        l_gripper_l_finger_pfs_b_right_3:
+                                        l_gripper_l_fingertip_pfs_b_right_3:
                                           {}
-                                      l_gripper_l_finger_pfs_b_top:
-                                        l_gripper_l_finger_pfs_b_top_0:
+                                      l_gripper_l_fingertip_pfs_b_top:
+                                        l_gripper_l_fingertip_pfs_b_top_0:
                                           {}
-                                        l_gripper_l_finger_pfs_b_top_1:
+                                        l_gripper_l_fingertip_pfs_b_top_1:
                                           {}
-                                        l_gripper_l_finger_pfs_b_top_2:
+                                        l_gripper_l_fingertip_pfs_b_top_2:
                                           {}
-                                        l_gripper_l_finger_pfs_b_top_3:
+                                        l_gripper_l_fingertip_pfs_b_top_3:
                                           {}
                                   l_gripper_led_frame:
                                     {}
@@ -1030,59 +1034,60 @@ Visualization Manager:
                                     l_gripper_r_finger_tip_link:
                                       l_gripper_l_finger_tip_frame:
                                         {}
-                                      l_gripper_r_finger_pfs_a:
-                                        l_gripper_r_finger_pfs_a_0:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_1:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_2:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_3:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_4:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_5:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_6:
-                                          {}
-                                        l_gripper_r_finger_pfs_a_7:
-                                          {}
-                                      l_gripper_r_finger_pfs_b_back:
-                                        l_gripper_r_finger_pfs_b_back_0:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_back_1:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_back_2:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_back_3:
-                                          {}
-                                      l_gripper_r_finger_pfs_b_left:
-                                        l_gripper_r_finger_pfs_b_left_0:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_left_1:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_left_2:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_left_3:
-                                          {}
-                                      l_gripper_r_finger_pfs_b_right:
-                                        l_gripper_r_finger_pfs_b_right_0:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_right_1:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_right_2:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_right_3:
-                                          {}
-                                      l_gripper_r_finger_pfs_b_top:
-                                        l_gripper_r_finger_pfs_b_top_0:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_top_1:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_top_2:
-                                          {}
-                                        l_gripper_r_finger_pfs_b_top_3:
-                                          {}
+                                      l_gripper_r_finger_tip_link_flipped:
+                                        l_gripper_r_fingertip_pfs_a:
+                                          l_gripper_r_fingertip_pfs_a_0:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_1:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_2:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_3:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_4:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_5:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_6:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_a_7:
+                                            {}
+                                        l_gripper_r_fingertip_pfs_b_back:
+                                          l_gripper_r_fingertip_pfs_b_back_0:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_back_1:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_back_2:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_back_3:
+                                            {}
+                                        l_gripper_r_fingertip_pfs_b_left:
+                                          l_gripper_r_fingertip_pfs_b_left_0:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_left_1:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_left_2:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_left_3:
+                                            {}
+                                        l_gripper_r_fingertip_pfs_b_right:
+                                          l_gripper_r_fingertip_pfs_b_right_0:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_right_1:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_right_2:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_right_3:
+                                            {}
+                                        l_gripper_r_fingertip_pfs_b_top:
+                                          l_gripper_r_fingertip_pfs_b_top_0:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_top_1:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_top_2:
+                                            {}
+                                          l_gripper_r_fingertip_pfs_b_top_3:
+                                            {}
                                   l_gripper_tool_frame:
                                     {}
               l_torso_lift_side_plate_link:
@@ -1105,58 +1110,58 @@ Visualization Manager:
                                 r_gripper_palm_link:
                                   r_gripper_l_finger_link:
                                     r_gripper_l_finger_tip_link:
-                                      r_gripper_l_finger_pfs_a:
-                                        r_gripper_l_finger_pfs_a_0:
+                                      r_gripper_l_fingertip_pfs_a:
+                                        r_gripper_l_fingertip_pfs_a_0:
                                           {}
-                                        r_gripper_l_finger_pfs_a_1:
+                                        r_gripper_l_fingertip_pfs_a_1:
                                           {}
-                                        r_gripper_l_finger_pfs_a_2:
+                                        r_gripper_l_fingertip_pfs_a_2:
                                           {}
-                                        r_gripper_l_finger_pfs_a_3:
+                                        r_gripper_l_fingertip_pfs_a_3:
                                           {}
-                                        r_gripper_l_finger_pfs_a_4:
+                                        r_gripper_l_fingertip_pfs_a_4:
                                           {}
-                                        r_gripper_l_finger_pfs_a_5:
+                                        r_gripper_l_fingertip_pfs_a_5:
                                           {}
-                                        r_gripper_l_finger_pfs_a_6:
+                                        r_gripper_l_fingertip_pfs_a_6:
                                           {}
-                                        r_gripper_l_finger_pfs_a_7:
+                                        r_gripper_l_fingertip_pfs_a_7:
                                           {}
-                                      r_gripper_l_finger_pfs_b_back:
-                                        r_gripper_l_finger_pfs_b_back_0:
+                                      r_gripper_l_fingertip_pfs_b_back:
+                                        r_gripper_l_fingertip_pfs_b_back_0:
                                           {}
-                                        r_gripper_l_finger_pfs_b_back_1:
+                                        r_gripper_l_fingertip_pfs_b_back_1:
                                           {}
-                                        r_gripper_l_finger_pfs_b_back_2:
+                                        r_gripper_l_fingertip_pfs_b_back_2:
                                           {}
-                                        r_gripper_l_finger_pfs_b_back_3:
+                                        r_gripper_l_fingertip_pfs_b_back_3:
                                           {}
-                                      r_gripper_l_finger_pfs_b_left:
-                                        r_gripper_l_finger_pfs_b_left_0:
+                                      r_gripper_l_fingertip_pfs_b_left:
+                                        r_gripper_l_fingertip_pfs_b_left_0:
                                           {}
-                                        r_gripper_l_finger_pfs_b_left_1:
+                                        r_gripper_l_fingertip_pfs_b_left_1:
                                           {}
-                                        r_gripper_l_finger_pfs_b_left_2:
+                                        r_gripper_l_fingertip_pfs_b_left_2:
                                           {}
-                                        r_gripper_l_finger_pfs_b_left_3:
+                                        r_gripper_l_fingertip_pfs_b_left_3:
                                           {}
-                                      r_gripper_l_finger_pfs_b_right:
-                                        r_gripper_l_finger_pfs_b_right_0:
+                                      r_gripper_l_fingertip_pfs_b_right:
+                                        r_gripper_l_fingertip_pfs_b_right_0:
                                           {}
-                                        r_gripper_l_finger_pfs_b_right_1:
+                                        r_gripper_l_fingertip_pfs_b_right_1:
                                           {}
-                                        r_gripper_l_finger_pfs_b_right_2:
+                                        r_gripper_l_fingertip_pfs_b_right_2:
                                           {}
-                                        r_gripper_l_finger_pfs_b_right_3:
+                                        r_gripper_l_fingertip_pfs_b_right_3:
                                           {}
-                                      r_gripper_l_finger_pfs_b_top:
-                                        r_gripper_l_finger_pfs_b_top_0:
+                                      r_gripper_l_fingertip_pfs_b_top:
+                                        r_gripper_l_fingertip_pfs_b_top_0:
                                           {}
-                                        r_gripper_l_finger_pfs_b_top_1:
+                                        r_gripper_l_fingertip_pfs_b_top_1:
                                           {}
-                                        r_gripper_l_finger_pfs_b_top_2:
+                                        r_gripper_l_fingertip_pfs_b_top_2:
                                           {}
-                                        r_gripper_l_finger_pfs_b_top_3:
+                                        r_gripper_l_fingertip_pfs_b_top_3:
                                           {}
                                   r_gripper_led_frame:
                                     {}
@@ -1169,59 +1174,60 @@ Visualization Manager:
                                     r_gripper_r_finger_tip_link:
                                       r_gripper_l_finger_tip_frame:
                                         {}
-                                      r_gripper_r_finger_pfs_a:
-                                        r_gripper_r_finger_pfs_a_0:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_1:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_2:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_3:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_4:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_5:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_6:
-                                          {}
-                                        r_gripper_r_finger_pfs_a_7:
-                                          {}
-                                      r_gripper_r_finger_pfs_b_back:
-                                        r_gripper_r_finger_pfs_b_back_0:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_back_1:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_back_2:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_back_3:
-                                          {}
-                                      r_gripper_r_finger_pfs_b_left:
-                                        r_gripper_r_finger_pfs_b_left_0:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_left_1:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_left_2:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_left_3:
-                                          {}
-                                      r_gripper_r_finger_pfs_b_right:
-                                        r_gripper_r_finger_pfs_b_right_0:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_right_1:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_right_2:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_right_3:
-                                          {}
-                                      r_gripper_r_finger_pfs_b_top:
-                                        r_gripper_r_finger_pfs_b_top_0:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_top_1:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_top_2:
-                                          {}
-                                        r_gripper_r_finger_pfs_b_top_3:
-                                          {}
+                                      r_gripper_r_finger_tip_link_flipped:
+                                        r_gripper_r_fingertip_pfs_a:
+                                          r_gripper_r_fingertip_pfs_a_0:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_1:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_2:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_3:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_4:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_5:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_6:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_a_7:
+                                            {}
+                                        r_gripper_r_fingertip_pfs_b_back:
+                                          r_gripper_r_fingertip_pfs_b_back_0:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_back_1:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_back_2:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_back_3:
+                                            {}
+                                        r_gripper_r_fingertip_pfs_b_left:
+                                          r_gripper_r_fingertip_pfs_b_left_0:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_left_1:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_left_2:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_left_3:
+                                            {}
+                                        r_gripper_r_fingertip_pfs_b_right:
+                                          r_gripper_r_fingertip_pfs_b_right_0:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_right_1:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_right_2:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_right_3:
+                                            {}
+                                        r_gripper_r_fingertip_pfs_b_top:
+                                          r_gripper_r_fingertip_pfs_b_top_0:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_top_1:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_top_2:
+                                            {}
+                                          r_gripper_r_fingertip_pfs_b_top_3:
+                                            {}
                                   r_gripper_tool_frame:
                                     {}
               r_torso_lift_side_plate_link:

--- a/launch/dummpy_pr2.launch
+++ b/launch/dummpy_pr2.launch
@@ -12,6 +12,9 @@
   <!-- Publish dummy /tf -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
+  <!-- Publish transform from fingertip to each pfs board -->
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_transform_publisher.launch" />
+
   <!-- RViz for PFS proximity and force sensors -->
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find pr2_fingertip_sensors)/config/pfs.rviz" />

--- a/launch/dummpy_pr2.launch
+++ b/launch/dummpy_pr2.launch
@@ -1,0 +1,19 @@
+<launch>
+
+  <!-- The following packages are not included to package.xml -->
+  <!-- because we add only ROS packages which is needed for real PR2 -->
+
+  <arg name="model" value="$(find pr2_description)/robots/pr2.urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model)" />
+
+  <!-- Publish dummy /joint_states -->
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>
+
+  <!-- Publish dummy /tf -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+  <!-- RViz for PFS proximity and force sensors -->
+  <node name="rviz" pkg="rviz" type="rviz"
+        args="-d $(find pr2_fingertip_sensors)/config/pfs.rviz" />
+
+</launch>

--- a/launch/pfs.launch
+++ b/launch/pfs.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="publish_pfs_tf" default="true"
+       doc="Publish static tf for pfs sensors. If you use PR2's default urdf, set this value as true" />
+  <arg name="gui" default="true" doc="Launch RViz or not" />
+
+  <node name="parse_pfs" pkg="pr2_fingertip_sensors" type="parse_pfs.py" output="screen" />
+  <node name="calibrate_pfs" pkg="pr2_fingertip_sensors" type="calibrate_pfs.py" output="screen" />
+  <node name="convert_pfs" pkg="pr2_fingertip_sensors" type="convert_pfs.py" output="screen" />
+
+  <!-- Publish transform from fingertip to each pfs board -->
+  <group if="$(arg publish_pfs_tf)">
+    <include file="$(find pr2_fingertip_sensors)/launch/pfs_transform_publisher.launch" />
+  </group>
+
+  <!-- RViz for PFS proximity and force sensors -->
+  <group if="$(arg gui)">
+    <node name="rviz" pkg="rviz" type="rviz"
+          args="-d $(find pr2_fingertip_sensors)/config/pfs.rviz" />
+  </group>
+</launch>

--- a/launch/pfs_a_to_sensor_transform_publisher.launch
+++ b/launch/pfs_a_to_sensor_transform_publisher.launch
@@ -1,0 +1,64 @@
+<launch>
+  <!-- static_transform_publisher's args -->
+  <!-- x y z qx qy qz qw frame_id child_frame_id  period_in_ms -->
+
+  <arg name="gripper" default="l" doc="'l' or 'r'" />
+  <arg name="finger" default="l" doc="'l' or 'r'" />
+  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a" />
+
+  <!-- PFS-01A's sensor 0 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_0_broadcaster"
+        args="-0.003 -0.006 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_0
+              100" />
+
+  <!-- PFS-01A's sensor 1 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_1_broadcaster"
+        args="0.003 -0.006 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_1
+              100" />
+
+  <!-- PFS-01A's sensor 2 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_2_broadcaster"
+        args="-0.003 -0.002 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_2
+              100" />
+
+  <!-- PFS-01A's sensor 3 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_3_broadcaster"
+        args="0.003 -0.002 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_3
+              100" />
+
+  <!-- PFS-01A's sensor 4 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_4_broadcaster"
+        args="-0.003 0.002 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_4
+              100" />
+
+  <!-- PFS-01A's sensor 5 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_5_broadcaster"
+        args="0.003 0.002 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_5
+              100" />
+
+  <!-- PFS-01A's sensor 6 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_6_broadcaster"
+        args="-0.003 0.002 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_6
+              100" />
+
+  <!-- PFS-01A's sensor 7 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_7_broadcaster"
+        args="0.003 0.002 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_7
+              100" />
+</launch>

--- a/launch/pfs_a_to_sensor_transform_publisher.launch
+++ b/launch/pfs_a_to_sensor_transform_publisher.launch
@@ -4,61 +4,61 @@
 
   <arg name="gripper" default="l" doc="'l' or 'r'" />
   <arg name="finger" default="l" doc="'l' or 'r'" />
-  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a" />
+  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a" />
 
   <!-- PFS-01A's sensor 0 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_0_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_0_broadcaster"
         args="-0.003 -0.006 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_0
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_0
               100" />
 
   <!-- PFS-01A's sensor 1 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_1_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_1_broadcaster"
         args="0.003 -0.006 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_1
               100" />
 
   <!-- PFS-01A's sensor 2 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_2_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_2_broadcaster"
         args="-0.003 -0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_2
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_2
               100" />
 
   <!-- PFS-01A's sensor 3 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_3_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_3_broadcaster"
         args="0.003 -0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_3
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_3
               100" />
 
   <!-- PFS-01A's sensor 4 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_4_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_4_broadcaster"
         args="-0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_4
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_4
               100" />
 
   <!-- PFS-01A's sensor 5 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_5_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_5_broadcaster"
         args="0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_5
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_5
               100" />
 
   <!-- PFS-01A's sensor 6 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_6_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_6_broadcaster"
         args="-0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_6
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_6
               100" />
 
   <!-- PFS-01A's sensor 7 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_7_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_7_broadcaster"
         args="0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a_7
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_7
               100" />
 </launch>

--- a/launch/pfs_a_to_sensor_transform_publisher.launch
+++ b/launch/pfs_a_to_sensor_transform_publisher.launch
@@ -2,63 +2,63 @@
   <!-- static_transform_publisher's args -->
   <!-- x y z qx qy qz qw frame_id child_frame_id  period_in_ms -->
 
-  <arg name="gripper" default="l" doc="'l' or 'r'" />
-  <arg name="finger" default="l" doc="'l' or 'r'" />
-  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a" />
+  <arg name="gripper" doc="'l' or 'r'" />
+  <arg name="finger" doc="'l' or 'r'" />
+  <arg name="parent_link" />
 
   <!-- PFS-01A's sensor 0 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_0_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_0_broadcaster"
         args="-0.003 -0.006 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_0
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_0
               100" />
 
   <!-- PFS-01A's sensor 1 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_1_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_1_broadcaster"
         args="0.003 -0.006 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_1
               100" />
 
   <!-- PFS-01A's sensor 2 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_2_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_2_broadcaster"
         args="-0.003 -0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_2
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_2
               100" />
 
   <!-- PFS-01A's sensor 3 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_3_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_3_broadcaster"
         args="0.003 -0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_3
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_3
               100" />
 
   <!-- PFS-01A's sensor 4 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_4_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_4_broadcaster"
         args="-0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_4
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_4
               100" />
 
   <!-- PFS-01A's sensor 5 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_5_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_5_broadcaster"
         args="0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_5
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_5
               100" />
 
   <!-- PFS-01A's sensor 6 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_6_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_6_broadcaster"
         args="-0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_6
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_6
               100" />
 
   <!-- PFS-01A's sensor 7 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_7_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_7_broadcaster"
         args="0.003 0.002 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_7
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_7
               100" />
 </launch>

--- a/launch/pfs_b_to_sensor_transform_publisher.launch
+++ b/launch/pfs_b_to_sensor_transform_publisher.launch
@@ -5,33 +5,33 @@
   <arg name="gripper" default="l" doc="'l' or 'r'" />
   <arg name="finger" default="l" doc="'l' or 'r'" />
   <arg name="part" default="top" doc="'top', 'back', 'left' or 'right'" />
-  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)" />
+  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)" />
 
   <!-- PFS-01B's sensor 0 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_0_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_0_broadcaster"
         args="-0.003 -0.003 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_0
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_0
               100" />
 
   <!-- PFS-01B's sensor 1 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_1_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_1_broadcaster"
         args="0.003 -0.003 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_1
               100" />
 
   <!-- PFS-01B's sensor 2 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_2_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_2_broadcaster"
         args="-0.003 0.003 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_2
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_2
               100" />
 
   <!-- PFS-01B's sensor 3 -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_3_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_3_broadcaster"
         args="0.003 0.003 0 0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_3
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)_3
               100" />
 </launch>

--- a/launch/pfs_b_to_sensor_transform_publisher.launch
+++ b/launch/pfs_b_to_sensor_transform_publisher.launch
@@ -2,10 +2,10 @@
   <!-- static_transform_publisher's args -->
   <!-- x y z qx qy qz qw frame_id child_frame_id  period_in_ms -->
 
-  <arg name="gripper" default="l" doc="'l' or 'r'" />
-  <arg name="finger" default="l" doc="'l' or 'r'" />
-  <arg name="part" default="top" doc="'top', 'back', 'left' or 'right'" />
-  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_$(arg part)" />
+  <arg name="gripper" doc="'l' or 'r'" />
+  <arg name="finger" doc="'l' or 'r'" />
+  <arg name="part" doc="'top', 'back', 'left' or 'right'" />
+  <arg name="parent_link" />
 
   <!-- PFS-01B's sensor 0 -->
   <node pkg="tf" type="static_transform_publisher"

--- a/launch/pfs_b_to_sensor_transform_publisher.launch
+++ b/launch/pfs_b_to_sensor_transform_publisher.launch
@@ -1,0 +1,37 @@
+<launch>
+  <!-- static_transform_publisher's args -->
+  <!-- x y z qx qy qz qw frame_id child_frame_id  period_in_ms -->
+
+  <arg name="gripper" default="l" doc="'l' or 'r'" />
+  <arg name="finger" default="l" doc="'l' or 'r'" />
+  <arg name="part" default="top" doc="'top', 'back', 'left' or 'right'" />
+  <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)" />
+
+  <!-- PFS-01B's sensor 0 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_0_broadcaster"
+        args="-0.003 -0.003 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_0
+              100" />
+
+  <!-- PFS-01B's sensor 1 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_1_broadcaster"
+        args="0.003 -0.003 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_1
+              100" />
+
+  <!-- PFS-01B's sensor 2 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_2_broadcaster"
+        args="-0.003 0.003 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_2
+              100" />
+
+  <!-- PFS-01B's sensor 3 -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_3_broadcaster"
+        args="0.003 0.003 0 0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_$(arg part)_3
+              100" />
+</launch>

--- a/launch/pfs_to_sensor_transform_publisher.launch
+++ b/launch/pfs_to_sensor_transform_publisher.launch
@@ -1,0 +1,78 @@
+<launch>
+  <!-- static_transform_publisher's args are -->
+  <!-- x y z qx qy qz qw frame_id child_frame_id  period_in_ms -->
+
+  <!-- To calculate quaternion, You can use (matrix2quaternion) function in euslisp -->
+  <!-- Note that (matrix2quaternion) returns (qw qx qy qz), not (qx qy qz qw) -->
+  <!-- Example -->
+  <!-- matrix2quaternion (rotate-matrix (rotate-matrix (unit-matrix 3) pi/2 :y) -pi/2 :z)) -->
+
+  <arg name="gripper" default="l" doc="'l' or 'r'" />
+  <arg name="finger" default="l" doc="'l' or 'r'" />
+  <arg name="parent_link" default="$(arg gripper)_gripper_$(arg finger)_finger_tip_link" />
+
+  <!-- Publish each sensor tf on PFS-01A tf from fingertip -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_broadcaster"
+        args="0.01 -0.015 0
+              0.5 0.5 -0.5 0.5
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_a_to_sensor_transform_publisher.launch">
+    <arg name="gripper" default="$(arg gripper)" />
+    <arg name="finger" default="$(arg finger)" />
+  </include>
+
+  <!-- Publish each sensor tf on PFS-01B top tf from fingertip -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_top_broadcaster"
+        args="0.03 -0.01 0
+              0.0 0.707107 0.0 0.707107
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_top
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
+    <arg name="gripper" default="$(arg gripper)" />
+    <arg name="finger" default="$(arg finger)" />
+    <arg name="part" default="top" />
+  </include>
+
+  <!-- Publish each sensor tf on PFS-01B back tf from fingertip -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_back_broadcaster"
+        args="0.03 -0.005 0
+              -0.5 0.5 0.5 0.5
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_back
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
+    <arg name="gripper" default="$(arg gripper)" />
+    <arg name="finger" default="$(arg finger)" />
+    <arg name="part" default="back" />
+  </include>
+
+  <!-- Publish each sensor tf on PFS-01B left tf from fingertip -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_left_broadcaster"
+        args="0.015 -0.01 0.01
+              0 0 0 1
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_left
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
+    <arg name="gripper" default="$(arg gripper)" />
+    <arg name="finger" default="$(arg finger)" />
+    <arg name="part" default="left" />
+  </include>
+
+  <!-- Publish each sensor tf on PFS-01B right tf from fingertip -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_right_broadcaster"
+        args="0.015 -0.01 -0.01
+              0 1 0 0
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_right
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
+    <arg name="gripper" default="$(arg gripper)" />
+    <arg name="finger" default="$(arg finger)" />
+    <arg name="part" default="right" />
+  </include>
+
+</launch>

--- a/launch/pfs_to_sensor_transform_publisher.launch
+++ b/launch/pfs_to_sensor_transform_publisher.launch
@@ -7,20 +7,21 @@
   <!-- Example -->
   <!-- matrix2quaternion (rotate-matrix (rotate-matrix (unit-matrix 3) pi/2 :y) -pi/2 :z)) -->
 
-  <arg name="gripper" default="l" doc="'l' or 'r'" />
-  <arg name="finger" default="l" doc="'l' or 'r'" />
-  <arg name="parent_link" default="$(arg gripper)_gripper_$(arg finger)_finger_tip_link" />
+  <arg name="gripper" doc="'l' or 'r'" />
+  <arg name="finger" doc="'l' or 'r'" />
+  <arg name="parent_link" />
 
   <!-- Publish each sensor tf on PFS-01A tf from fingertip -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front_broadcaster"
         args="0.01 -0.015 0
               0.5 0.5 -0.5 0.5
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_a_to_sensor_transform_publisher.launch">
-    <arg name="gripper" default="$(arg gripper)" />
-    <arg name="finger" default="$(arg finger)" />
+    <arg name="gripper" value="$(arg gripper)" />
+    <arg name="finger" value="$(arg finger)" />
+    <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_front" />
   </include>
 
   <!-- Publish each sensor tf on PFS-01B top tf from fingertip -->
@@ -31,9 +32,10 @@
               $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_top
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
-    <arg name="gripper" default="$(arg gripper)" />
-    <arg name="finger" default="$(arg finger)" />
-    <arg name="part" default="top" />
+    <arg name="gripper" value="$(arg gripper)" />
+    <arg name="finger" value="$(arg finger)" />
+    <arg name="part" value="top" />
+    <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_top" />
   </include>
 
   <!-- Publish each sensor tf on PFS-01B back tf from fingertip -->
@@ -44,9 +46,10 @@
               $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_back
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
-    <arg name="gripper" default="$(arg gripper)" />
-    <arg name="finger" default="$(arg finger)" />
-    <arg name="part" default="back" />
+    <arg name="gripper" value="$(arg gripper)" />
+    <arg name="finger" value="$(arg finger)" />
+    <arg name="part" value="back" />
+    <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_back" />
   </include>
 
   <!-- Publish each sensor tf on PFS-01B left tf from fingertip -->
@@ -57,9 +60,10 @@
               $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_left
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
-    <arg name="gripper" default="$(arg gripper)" />
-    <arg name="finger" default="$(arg finger)" />
-    <arg name="part" default="left" />
+    <arg name="gripper" value="$(arg gripper)" />
+    <arg name="finger" value="$(arg finger)" />
+    <arg name="part" value="left" />
+    <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_left" />
   </include>
 
   <!-- Publish each sensor tf on PFS-01B right tf from fingertip -->
@@ -70,9 +74,10 @@
               $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_right
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
-    <arg name="gripper" default="$(arg gripper)" />
-    <arg name="finger" default="$(arg finger)" />
-    <arg name="part" default="right" />
+    <arg name="gripper" value="$(arg gripper)" />
+    <arg name="finger" value="$(arg finger)" />
+    <arg name="part" value="right" />
+    <arg name="parent_link" value="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_right" />
   </include>
 
 </launch>

--- a/launch/pfs_to_sensor_transform_publisher.launch
+++ b/launch/pfs_to_sensor_transform_publisher.launch
@@ -13,10 +13,10 @@
 
   <!-- Publish each sensor tf on PFS-01A tf from fingertip -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_a_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a_broadcaster"
         args="0.01 -0.015 0
               0.5 0.5 -0.5 0.5
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_a
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_a
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_a_to_sensor_transform_publisher.launch">
     <arg name="gripper" default="$(arg gripper)" />
@@ -25,10 +25,10 @@
 
   <!-- Publish each sensor tf on PFS-01B top tf from fingertip -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_top_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_top_broadcaster"
         args="0.03 -0.01 0
               0.0 0.707107 0.0 0.707107
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_top
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_top
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
     <arg name="gripper" default="$(arg gripper)" />
@@ -38,10 +38,10 @@
 
   <!-- Publish each sensor tf on PFS-01B back tf from fingertip -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_back_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_back_broadcaster"
         args="0.03 -0.005 0
               -0.5 0.5 0.5 0.5
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_back
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_back
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
     <arg name="gripper" default="$(arg gripper)" />
@@ -51,10 +51,10 @@
 
   <!-- Publish each sensor tf on PFS-01B left tf from fingertip -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_left_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_left_broadcaster"
         args="0.015 -0.01 0.01
               0 0 0 1
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_left
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_left
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
     <arg name="gripper" default="$(arg gripper)" />
@@ -64,10 +64,10 @@
 
   <!-- Publish each sensor tf on PFS-01B right tf from fingertip -->
   <node pkg="tf" type="static_transform_publisher"
-        name="$(arg gripper)_gripper_$(arg finger)_finger_pfs_b_right_broadcaster"
+        name="$(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_right_broadcaster"
         args="0.015 -0.01 -0.01
               0 1 0 0
-              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_finger_pfs_b_right
+              $(arg parent_link) $(arg gripper)_gripper_$(arg finger)_fingertip_pfs_b_right
               100" />
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_b_to_sensor_transform_publisher.launch">
     <arg name="gripper" default="$(arg gripper)" />

--- a/launch/pfs_transform_publisher.launch
+++ b/launch/pfs_transform_publisher.launch
@@ -1,0 +1,43 @@
+<launch>
+
+  <!-- Publish each sensor tf from left gripper left finger -->
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_to_sensor_transform_publisher.launch">
+    <arg name="gripper" value="l" />
+    <arg name="finger" value="l" />
+  </include>
+
+  <!-- Publish each sensor tf from left gripper right finger -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="l_gripper_r_finger_tip_link_flipped_broadcaster"
+        args="0 0 0
+              1 0 0 0
+              l_gripper_r_finger_tip_link
+              l_gripper_r_finger_tip_link_flipped
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_to_sensor_transform_publisher.launch">
+    <arg name="gripper" value="l" />
+    <arg name="finger" value="r" />
+    <arg name="parent_link" value="l_gripper_r_finger_tip_link_flipped" />
+  </include>
+
+  <!-- Publish each sensor tf from right gripper left finger -->
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_to_sensor_transform_publisher.launch">
+    <arg name="gripper" value="r" />
+    <arg name="finger" value="l" />
+  </include>
+
+  <!-- Publish each sensor tf from right gripper right finger -->
+  <node pkg="tf" type="static_transform_publisher"
+        name="r_gripper_r_finger_tip_link_flipped_broadcaster"
+        args="0 0 0
+              1 0 0 0
+              r_gripper_r_finger_tip_link
+              r_gripper_r_finger_tip_link_flipped
+              100" />
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs_to_sensor_transform_publisher.launch">
+    <arg name="gripper" value="r" />
+    <arg name="finger" value="r" />
+    <arg name="parent_link" value="r_gripper_r_finger_tip_link_flipped" />
+  </include>
+
+</launch>

--- a/launch/pfs_transform_publisher.launch
+++ b/launch/pfs_transform_publisher.launch
@@ -4,6 +4,7 @@
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_to_sensor_transform_publisher.launch">
     <arg name="gripper" value="l" />
     <arg name="finger" value="l" />
+    <arg name="parent_link" value="l_gripper_l_finger_tip_link" />
   </include>
 
   <!-- Publish each sensor tf from left gripper right finger -->
@@ -24,6 +25,7 @@
   <include file="$(find pr2_fingertip_sensors)/launch/pfs_to_sensor_transform_publisher.launch">
     <arg name="gripper" value="r" />
     <arg name="finger" value="l" />
+    <arg name="parent_link" value="r_gripper_l_finger_tip_link" />
   </include>
 
   <!-- Publish each sensor tf from right gripper right finger -->

--- a/sample/sample_pfs.launch
+++ b/sample/sample_pfs.launch
@@ -1,0 +1,15 @@
+<launch>
+  <arg name="model" value="$(find pr2_description)/robots/pr2.urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model)" />
+  <param name="use_sim_time" value="true" />
+
+  <!-- Play rosbag including /pressure/{l or r}_gripper_motor topics -->
+  <node name="play_pfs" pkg="rosbag" type="play"
+        args="--clock --loop $(find pr2_fingertip_sensors)/data/sample_pfs.bag" />
+
+  <!-- Launch pfs.launch -->
+  <include file="$(find pr2_fingertip_sensors)/launch/pfs.launch">
+    <arg name="publish_pfs_tf" value="true" />
+    <arg name="gui" value="true" />
+  </include>
+</launch>

--- a/scripts/calibrate_pfs.py
+++ b/scripts/calibrate_pfs.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import rospy
+from pr2_fingertip_sensors.msg import PR2FingertipSensor
+
+
+class CalibratePFS(object):
+    """
+    Calibrate PR2FingertipSensor message (proximity, force and imu message)
+    """
+    def __init__(self):
+        self.grippers = ['l_gripper', 'r_gripper']
+        self.fingertips = ['l_fingertip', 'r_fingertip']
+        self.pub = {}
+        for gripper in self.grippers:
+            self.pub[gripper] = {}
+            for fingertip in self.fingertips:
+                # Subscribe raw data
+                rospy.Subscriber(
+                    '/pfs/{}/{}/raw'.format(gripper, fingertip),
+                    PR2FingertipSensor, self.cb, gripper, fingertip)
+                # Publish calibrated data
+                self.pub[gripper][fingertip] = rospy.Publisher(
+                    '/pfs/{}/{}'.format(gripper, fingertip),
+                    PR2FingertipSensor, queue_size=1)
+
+    def cb(self, msg, gripper, fingertip):
+        """
+        Publish calibrated PFS sensor data
+        """
+        msg_calibrated = self.calibrate(msg)
+        self.pub[gripper][fingertip].publish(msg_calibrated)
+
+    def calibrate(msg):
+        """
+        Calibrate sensor data
+        """
+        # TODO
+        return msg
+
+
+if __name__ == '__main__':
+    rospy.init_node('calibrate_pfs')
+    cp = CalibratePFS()
+    rospy.spin()

--- a/scripts/calibrate_pfs.py
+++ b/scripts/calibrate_pfs.py
@@ -18,24 +18,27 @@ class CalibratePFS(object):
                 # Subscribe raw data
                 rospy.Subscriber(
                     '/pfs/{}/{}/raw'.format(gripper, fingertip),
-                    PR2FingertipSensor, self.cb, gripper, fingertip)
+                    PR2FingertipSensor, self.cb, (gripper, fingertip))
                 # Publish calibrated data
                 self.pub[gripper][fingertip] = rospy.Publisher(
                     '/pfs/{}/{}'.format(gripper, fingertip),
                     PR2FingertipSensor, queue_size=1)
 
-    def cb(self, msg, gripper, fingertip):
+    def cb(self, msg, args):
         """
         Publish calibrated PFS sensor data
+        args must be tuple of (gripper, fingertip)
         """
+        gripper = args[0]
+        fingertip = args[1]
         msg_calibrated = self.calibrate(msg)
         self.pub[gripper][fingertip].publish(msg_calibrated)
 
-    def calibrate(msg):
+    def calibrate(self, msg):
         """
         Calibrate sensor data
         """
-        # TODO
+        # Need calibration for proximity and force sensors
         return msg
 
 

--- a/scripts/convert_pfs.py
+++ b/scripts/convert_pfs.py
@@ -55,7 +55,7 @@ class ConvertPFS(object):
         fingertip = args[1]
         self.publish_pointcloud(msg, gripper, fingertip)
         self.publish_wrenchstamped(msg, gripper, fingertip)
-        self.pub[gripper][fingertip]['pfs_a_front']['imu'].publish(msg.imu)
+        self.publish_imu(msg, gripper, fingertip)
 
     def sensor_num(self, part):
         """
@@ -146,6 +146,22 @@ class ConvertPFS(object):
             force_scale = 0.00005  # TODO: Convert force topic value into [N]
             force_msg.wrench.force.z = average_force * force_scale
             self.pub[gripper][fingertip][part]['force'].publish(force_msg)
+
+    def publish_imu(self, msg, gripper, fingertip):
+        imu = msg.imu
+        # Gyro
+        gyro = imu.angular_velocity
+        gyro_scale = 0.001  # TODO: Proper unit?
+        msg.imu.angular_velocity.x = gyro.x * gyro_scale
+        msg.imu.angular_velocity.y = gyro.y * gyro_scale
+        msg.imu.angular_velocity.z = gyro.z * gyro_scale
+        # Acceleration
+        acc = imu.linear_acceleration
+        acc_scale = 0.001  # TODO: Proper unit?
+        msg.imu.linear_acceleration.x = acc.x * acc_scale
+        msg.imu.linear_acceleration.y = acc.y * acc_scale
+        msg.imu.linear_acceleration.z = acc.z * acc_scale
+        self.pub[gripper][fingertip]['pfs_a_front']['imu'].publish(msg.imu)
 
 
 if __name__ == '__main__':

--- a/scripts/convert_pfs.py
+++ b/scripts/convert_pfs.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+
+import math
+import rospy
+from pr2_fingertip_sensors.msg import PR2FingertipSensor
+from sensor_msgs.msg import Imu, PointCloud2, PointField, WrenchStamped
+import sensor_msgs.point_cloud2 as pc2
+from std_msgs.msg import Header
+
+
+class ConvertPFS(object):
+    """
+    Convert PR2FingertipSensor message into proximity, force and imu message
+    - proximity(sensor_msgs/PointCloud2)
+    - force(geometry_msgs/WrenchStamped)
+    - imu(sensor_msgs/Imu)
+    """
+    def __init__(self):
+        self.grippers = ['l_gripper', 'r_gripper']
+        self.fingertips = ['l_fingertip', 'r_fingertip']
+        self.parts = [
+            'pfs_a', 'pfs_b_top', 'pfs_b_back', 'pfs_b_left', 'pfs_b_right']
+        self.pub = {}
+        for gripper in self.grippers:
+            self.pub[gripper] = {}
+            for fingertip in self.fingertips:
+                # Subscriber
+                rospy.Subscriber(
+                    '/pfs/{}/{}'.format(gripper, fingertip),
+                    PR2FingertipSensor, self.cb, gripper, fingertip)
+                # Publisher for proximity, force and imu
+                self.pub[gripper][fingertip] = {}
+                for part in self.parts:
+                    sensors = ['proximity', 'force', 'imu']
+                    msg_types = [PointCloud2, WrenchStamped, Imu]
+                    for sensor, msg_type in zip(sensors, msg_types):
+                        if part != 'pfs_a' and sensor == 'imu':
+                            continue
+                        self.pub[gripper][fingertip][part][sensor] = rospy.Publisher(
+                            '/pfs/{}/{}/{}/{}'.format(
+                                gripper, fingertip, part, sensor),
+                            msg_type, queue_size=1)
+        self.fields = [PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=8),
+                       PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=8),
+                       PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=8)]
+
+    def cb(self, msg, gripper, fingertip):
+        """
+        publish each sensor data
+        """
+        self.publish_pointcloud(msg, gripper, fingertip)
+        self.publish_wrenchstamped(msg, gripper, fingertip)
+        self.pub[gripper][fingertip]['pfs_a']['imu'].publish(msg.imu)
+
+    def sensor_num(self, part):
+        """
+        Args
+        part: 'pfs_a', 'pfs_b_top', 'pfs_b_back', 'pfs_b_left' or 'pfs_b_right'
+
+        Return
+        sensor_num: The number of sensors in the specified PCB.
+        """
+        if part == 'pfs_a':
+            sensor_num = 8
+        else:
+            sensor_num = 4
+        return sensor_num
+
+    def sensor_index(self, part, i):
+        """
+        Args
+        part: 'pfs_a', 'pfs_b_top', 'pfs_b_back', 'pfs_b_left' or 'pfs_b_right'
+        i: The index of sensor in each PCB. 0~7 for pfs_a. 0~3 for pfs_b.
+
+        Return
+        index: The index of sensor in all PCBs. This value is between 0~23.
+        """
+        if part == 'pfs_a':
+            index = i
+        elif part == 'pfs_b_top':
+            index = 8 + i
+        elif part == 'pfs_b_back':
+            index = 12 + i
+        elif part == 'pfs_b_left':
+            index = 16 + i
+        elif part == 'pfs_b_right':
+            index = 20 + i
+        return index
+
+    def proximity_to_distance(self, proximity, gripper, fingertip, part, i):
+        """
+        Args
+        proximity: The raw proximity value
+        gripper: 'l_gripper' or 'r_gripper'
+        fingertips: 'l_fingertip' or 'r_fingertip'
+        part: 'pfs_a', 'pfs_b_top', 'pfs_b_back', 'pfs_b_left' or 'pfs_b_right'
+        i: The index of sensor in each PCB. 0~7 for pfs_a. 0~3 for pfs_b.
+
+        Return
+        distance: Distance calculated from proximity value [m]
+        """
+        # Create method for conversion
+        # I = (a / d^2) + b
+        b = 100
+        a = 0.01
+        distance = math.sqrt(
+            a / max(0.1, proximity - b))  # unit: [m]
+        return distance
+
+    def publish_pointcloud(self, msg, gripper, fingertip):
+        header = Header()
+        header.stamp = msg.header.stamp
+        for part in self.parts:
+            header.frame_id = '/' + gripper + '_' + fingertip + '_' + part
+            sensor_num = self.sensor_num(part)
+            points = []
+            for i in range(sensor_num):
+                index = self.sensor_index(part, i)  # index: 0~23
+                # Convert proximity into PointCloud2
+                distance = self.proximity_to_distance(
+                    msg.proximity[index], gripper, fingertip, part, i)
+                point = [0, 0, distance]
+                point.append = point
+            prox_msg = pc2.create_cloud(header, self.fields, points)
+            self.pub[gripper][fingertip][part]['proximity'].publish(prox_msg)
+
+    def publish_wrenchstamped(self, msg, gripper, fingertip):
+        header = Header()
+        header.stamp = msg.header.stamp
+        for part in self.parts:
+            header.frame_id = '/' + gripper + '_' + fingertip + '_' + part
+            sensor_num = self.sensor_num(part)
+            average_force = 0.0
+            for i in range(sensor_num):
+                index = self.sensor_index(part, i)  # index: 0~23
+                # Convert force into WrenchStamped
+                average_force += msg.force[index] / float(sensor_num)
+            # Publish force
+            force_msg = WrenchStamped()
+            force_msg.header = header
+            force_msg.wrench.force.z = average_force
+            self.pub[gripper][fingertip][part]['force'].publish(force_msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('parse_pfs')
+    pp = ConvertPFS()
+    rospy.spin()

--- a/scripts/parse_pfs.py
+++ b/scripts/parse_pfs.py
@@ -19,8 +19,8 @@ class ParsePFS(object):
             self.pub[gripper] = {}
             for fingertip in self.fingertips:
                 self.pub[gripper][fingertip] = rospy.Publisher(
-                    '/pfs/' + gripper + '/' + fingertip, PR2FingertipSensor,
-                    queue_size=1)
+                    '/pfs/' + gripper + '/' + fingertip + '/raw',
+                    PR2FingertipSensor, queue_size=1)
         # Subscribers
         rospy.Subscriber(
             "/pressure/l_gripper_motor", PressureState, self.cb, "l_gripper")
@@ -78,7 +78,7 @@ class ParsePFS(object):
         pfs_msg.proximity = proximity
         pfs_msg.force = force
         pfs_msg.imu.header.stamp = header.stamp
-        imu_frame_id = '/' + gripper + '_' + fingertip + '_' + 'pfs_a'
+        imu_frame_id = '/' + gripper + '_' + fingertip + '_' + 'pfs_a_front'
         pfs_msg.imu.header.frame_id = imu_frame_id
         pfs_msg.imu.linear_acceleration.x = acc[0]
         pfs_msg.imu.linear_acceleration.y = acc[1]

--- a/scripts/parse_pfs.py
+++ b/scripts/parse_pfs.py
@@ -6,6 +6,10 @@ from pr2_fingertip_sensors.msg import PR2FingertipSensor
 
 
 class ParsePFS(object):
+    """
+    Get and parse two /pressure/{l or r}_gripper_motor topics.
+    Concatenate them into one /pfs/{l or r}_gripper/{l or r}_finger topic.
+    """
     def __init__(self):
         self.grippers = ['l_gripper', 'r_gripper']
         self.fingertips = ['l_fingertip', 'r_fingertip']
@@ -73,6 +77,9 @@ class ParsePFS(object):
         pfs_msg.header = header
         pfs_msg.proximity = proximity
         pfs_msg.force = force
+        pfs_msg.imu.header.stamp = header.stamp
+        imu_frame_id = '/' + gripper + '_' + fingertip + '_' + 'pfs_a'
+        pfs_msg.imu.header.frame_id = imu_frame_id
         pfs_msg.imu.linear_acceleration.x = acc[0]
         pfs_msg.imu.linear_acceleration.y = acc[1]
         pfs_msg.imu.linear_acceleration.z = acc[2]

--- a/scripts/parse_pfs.py
+++ b/scripts/parse_pfs.py
@@ -41,8 +41,10 @@ class ParsePFS(object):
         for fingertip in self.fingertips:
             if fingertip == 'l_fingertip':
                 data = self.parse(msg.l_finger_tip)
+                frame_id = gripper + '_l_finger_tip_link'
             if fingertip == 'r_fingertip':
                 data = self.parse(msg.r_finger_tip)
+                frame_id = gripper + '_r_finger_tip_link'
             # Store parsed sensor data
             self.pfs_data[gripper][fingertip][data['packet_type']] = data
             # If all sensor data is stored, append them
@@ -50,6 +52,7 @@ class ParsePFS(object):
                and self.pfs_data[gripper][fingertip][1] is not None:
                 # Create method?
                 header = msg.header
+                header.frame_id = frame_id
                 prox = self.pfs_data[gripper][fingertip][0]['proximity'] + \
                     self.pfs_data[gripper][fingertip][1]['proximity']
                 force = self.pfs_data[gripper][fingertip][0]['force'] + \


### PR DESCRIPTION
PFSセンサデータ（Proximity, Force, IMU）をRVizで可視化しました。
TFを何となく合わせただけ + 各センサのキャリブレーションをしていないので、値はじゃっかん変です。

- 緑の点：近接センサから計算された点群
- 赤の矢印：Force
- 紫の矢印：IMU

サンプルrosbagもgit pushしているので、以下のコマンドで可視化プログラムを使えます。
```
roslaunch pr2_fingertip_sensors sample_pfs.launch
```

今後のTODOとしては、
- TFの場所をより正確に合わせる
- calibrate_pfs.pyに、各センサのキャリブレーション用プログラムを追加する
- キャリブレーションで得られたデータをどこに格納するかを考える。そもそものデータはdata/pfs.yamlなどに保管するのか。実際に利用するときはrostopicに入れるのかrosparamでセットするのか。

![Screenshot from 2022-11-03 01-22-20](https://user-images.githubusercontent.com/19769486/199544966-b43c8f8f-2df4-43da-a6f2-83a6872c4bec.png)
