### PR TITLE
Publish proximity distance and force for each sensor

### DIFF
--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -560,7 +560,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -590,7 +590,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -620,7 +620,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -650,7 +650,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -680,7 +680,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/4
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/4
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -710,7 +710,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/5
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/5
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -740,7 +740,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/6
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/6
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -770,7 +770,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity/7
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/proximity_cloud/7
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -804,7 +804,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity/0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -834,7 +834,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity/1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -864,7 +864,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity/2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -894,7 +894,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity/3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -928,7 +928,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity/0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -958,7 +958,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity/1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -988,7 +988,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity/2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1018,7 +1018,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity/3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1052,7 +1052,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity/0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1082,7 +1082,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity/1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1112,7 +1112,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity/2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1142,7 +1142,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity/3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1176,7 +1176,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity/0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1206,7 +1206,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity/1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1236,7 +1236,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity/2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1266,7 +1266,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity/3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1286,7 +1286,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: A_Front
-              Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force
+              Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -1300,7 +1300,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Top
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/force
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -1314,7 +1314,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Back
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/force
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -1328,7 +1328,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Left
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/force
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -1342,7 +1342,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Right
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/force
+              Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -1391,7 +1391,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1421,7 +1421,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1451,7 +1451,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1481,7 +1481,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1511,7 +1511,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/4
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/4
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1541,7 +1541,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/5
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/5
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1571,7 +1571,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/6
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/6
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1601,7 +1601,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity/7
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/proximity_cloud/7
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1635,7 +1635,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity/0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1665,7 +1665,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity/1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1695,7 +1695,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity/2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1725,7 +1725,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity/3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1759,7 +1759,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity/0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1789,7 +1789,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity/1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1819,7 +1819,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity/2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1849,7 +1849,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity/3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1883,7 +1883,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity/0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1913,7 +1913,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity/1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1943,7 +1943,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity/2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -1973,7 +1973,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity/3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2007,7 +2007,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity/0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2037,7 +2037,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity/1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2067,7 +2067,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity/2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2097,7 +2097,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity/3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2117,7 +2117,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: A_Front
-              Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force
+              Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2131,7 +2131,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Top
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/force
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2145,7 +2145,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Back
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/force
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2159,7 +2159,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Left
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/force
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2173,7 +2173,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Right
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/force
+              Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2222,7 +2222,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2252,7 +2252,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2282,7 +2282,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2312,7 +2312,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2342,7 +2342,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/4
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/4
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2372,7 +2372,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/5
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/5
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2402,7 +2402,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/6
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/6
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2432,7 +2432,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity/7
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/proximity_cloud/7
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2466,7 +2466,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity/0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2496,7 +2496,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity/1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2526,7 +2526,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity/2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2556,7 +2556,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity/3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2590,7 +2590,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity/0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2620,7 +2620,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity/1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2650,7 +2650,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity/2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2680,7 +2680,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity/3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2714,7 +2714,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity/0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2744,7 +2744,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity/1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2774,7 +2774,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity/2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2804,7 +2804,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity/3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2838,7 +2838,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity/0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2868,7 +2868,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity/1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2898,7 +2898,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity/2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2928,7 +2928,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity/3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -2948,7 +2948,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: A_Front
-              Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force
+              Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2962,7 +2962,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Top
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/force
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2976,7 +2976,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Back
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/force
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -2990,7 +2990,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Left
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/force
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -3004,7 +3004,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Right
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/force
+              Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -3053,7 +3053,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3083,7 +3083,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3113,7 +3113,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3143,7 +3143,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3173,7 +3173,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/4
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/4
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3203,7 +3203,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/5
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/5
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3233,7 +3233,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/6
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/6
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3263,7 +3263,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity/7
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/proximity_cloud/7
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3297,7 +3297,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity/0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3327,7 +3327,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity/1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3357,7 +3357,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity/2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3387,7 +3387,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity/3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3421,7 +3421,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity/0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3451,7 +3451,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity/1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3481,7 +3481,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity/2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3511,7 +3511,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity/3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3545,7 +3545,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity/0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3575,7 +3575,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity/1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3605,7 +3605,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity/2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3635,7 +3635,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity/3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3669,7 +3669,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity/0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity_cloud/0
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3699,7 +3699,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity/1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity_cloud/1
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3729,7 +3729,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity/2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity_cloud/2
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3759,7 +3759,7 @@ Visualization Manager:
                   Size (Pixels): 5
                   Size (m): 0.009999999776482582
                   Style: Points
-                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity/3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/proximity_cloud/3
                   Unreliable: false
                   Use Fixed Frame: true
                   Use rainbow: true
@@ -3779,7 +3779,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: A_Front
-              Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force
+              Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -3793,7 +3793,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Top
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/force
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -3807,7 +3807,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Back
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/force
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -3821,7 +3821,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Left
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/force
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false
@@ -3835,7 +3835,7 @@ Visualization Manager:
               Hide Small Values: false
               History Length: 1
               Name: B_Right
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/force
+              Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/wrench
               Torque Arrow Scale: 1
               Torque Color: 204; 204; 51
               Unreliable: false

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,10 +38,24 @@ Here, to avoid duplicate expressions, multiple topic names are summarized by abb
   ROS topics decomposed for each sensor. `pr2_fingertip_sensors/config/pfs.rviz` visualizes the second, third and fifth topics.
 
   - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/force/{sensor_num}` (`std_msgs/Float32`)
+
+  Force value. One topic per force sensor.
+
   - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/wrench` (`geometry_msgs/WrenchStamped`)
+
+  Wrench value. One topic per PFS board.
+
   - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/imu` (`sensor_msgs/Imu`)
+
+  IMU value. One topic per PFS A board.
+
   - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/proximity_distance/{sensor_num}` (`std_msgs/Float32`)
+
+  Distance calculated from each proximity sensor. One topic per proximity sensor.
+
   - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/proximity_cloud/{sensor_num}` (`sensor_msgs/PointCloud2`)
+
+  Pointcloud calculated from each proximity sensor. One topic per proximity sensor.
 
 ## Parameters
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,7 @@ Here, to avoid duplicate expressions, multiple topic names are summarized by abb
 
   Parsed PFS topics.
 
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip` [`pr2_fingertip_sensors/PR2FingertipSensor`]
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip` (`pr2_fingertip_sensors/PR2FingertipSensor`)
 
 # convert_pfs.py
 
@@ -31,17 +31,17 @@ Here, to avoid duplicate expressions, multiple topic names are summarized by abb
 
   Parsed PFS topics.
 
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip` [`pr2_fingertip_sensors/PR2FingertipSensor`]
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip` (`pr2_fingertip_sensors/PR2FingertipSensor`)
 
 ## Publish topics
 
-  ROS topics decomposed for each sensor.
-  The last proximity topics are for RViz visualization.
+  ROS topics decomposed for each sensor. `pr2_fingertip_sensors/config/pfs.rviz` visualizes the second, third and fifth topics.
 
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/force` [`geometry_msgs/WrenchStamped`]
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/imu` [`sensor_msgs/Imu`]
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/proximity` [`sensor_msgs/PointCloud2`]
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/proximity/{sensor_num}` [`sensor_msgs/PointCloud2`]
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/force/{sensor_num}` (`std_msgs/Float32`)
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/wrench` (`geometry_msgs/WrenchStamped`)
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/imu` (`sensor_msgs/Imu`)
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/proximity_distance/{sensor_num}` (`std_msgs/Float32`)
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip/{part}/proximity_cloud/{sensor_num}` (`sensor_msgs/PointCloud2`)
 
 ## Parameters
 
@@ -60,7 +60,7 @@ Here, to avoid duplicate expressions, multiple topic names are summarized by abb
 
   Parsed PFS topics.
 
-  - `/pfs/{l_r}_gripper/{l_r}_fingertip` [`pr2_fingertip_sensors/PR2FingertipSensor`]
+  - `/pfs/{l_r}_gripper/{l_r}_fingertip` (`pr2_fingertip_sensors/PR2FingertipSensor`)
 
 ## Publish topics
 
@@ -70,20 +70,20 @@ None
 
 ### Calibrate proximity sensor
 
-  Calibrate proximity parameters 'b' in I = (a / d^2) + b. Run the following command when nothing is near the PFS finger.
+  Calibrate proximity parameters 'b' in I = (a / d^2) + b. Run the following command when nothing is near the PFS finger. The calibration result is saved to rosparam `/pfs/{l_r}_gripper/{l_r}_fingertip/proximity_b`.
 
-  - `/pfs/no_object` [`std_srvs/Empty`]
+  - `/pfs/no_object` (`std_srvs/Empty`)
 
-  Calibrate proximity parameters 'a' in I = (a / d^2) + b. Run the following command after wrapping the PFS finger with white conver. This command must be called after the above command.
+  Calibrate proximity parameters 'a' in I = (a / d^2) + b. Run the following command after wrapping the PFS finger with white conver. This command must be called after the above command. The calibration result is saved to rosparam `/pfs/{l_r}_gripper/{l_r}_fingertip/proximity_a`.
 
-  - `/pfs/near_object` [`std_srvs/Empty`]
+  - `/pfs/near_object` (`std_srvs/Empty`)
 
 ### Calibrate force sensor
 
-  Calibrate force sensor preload. Run the following command when nothing touches the PFS finger.
+  Calibrate force sensor preload. Run the following command when nothing touches the PFS finger. The calibration result is saved to rosparam `/pfs/{l_r}_gripper/{l_r}_fingertip/preload`.
 
-  - `/pfs/preload` [`std_srvs/Empty`]
+  - `/pfs/preload` (`std_srvs/Empty`)
 
 ### Dump calibration params
 
-  Dump calibration parameters to yaml file (`pr2_fingertip_sensors/data/pfs_params.yaml`).
+  Dump calibration rosparams to yaml file (`pr2_fingertip_sensors/data/pfs_params.yaml`).

--- a/scripts/convert_pfs.py
+++ b/scripts/convert_pfs.py
@@ -12,11 +12,11 @@ from std_msgs.msg import Float32, Header
 class ConvertPFS(object):
     """
     Convert PR2FingertipSensor message into the following messages
-    - proximity_cloud(sensor_msgs/PointCloud2), pointcloud calculated from each proximity sensor
-    - proximity_distance(std_msgs/Float32), distance calculated from each proximity sensor
-    - wrench(geometry_msgs/WrenchStamped), wrench value for each PFS board
-    - force(geometry_msgs/Vector3), force value for each force sensor
-    - imu(sensor_msgs/Imu), IMU value for PFS A board
+    - proximity_cloud(sensor_msgs/PointCloud2), pointcloud calculated from each proximity sensor. One topic per proximity sensor.
+    - proximity_distance(std_msgs/Float32), distance calculated from each proximity sensor. One topic per proximity sensor.
+    - wrench(geometry_msgs/WrenchStamped), wrench value. One topic per PFS board.
+    - force(std_msgs/Float32), force value. One topic per force sensor.
+    - imu(sensor_msgs/Imu), IMU value. One topic per PFS A board.
     """
     def __init__(self):
         self.grippers = ['l_gripper', 'r_gripper']
@@ -139,8 +139,8 @@ class ConvertPFS(object):
     def publish_proximity(self, msg, gripper, fingertip):
         """
         Publish the following topics
-        - proximity_cloud(sensor_msgs/PointCloud2), pointcloud calculated from each proximity sensor
-        - proximity_distance(std_msgs/Float32), distance calculated from each proximity sensor
+        - proximity_cloud(sensor_msgs/PointCloud2), pointcloud calculated from each proximity sensor. One topic per proximity sensor.
+        - proximity_distance(std_msgs/Float32), distance calculated from each proximity sensor. One topic per proximity sensor.
         """
         header = Header()
         header.stamp = msg.header.stamp
@@ -164,8 +164,8 @@ class ConvertPFS(object):
     def publish_force(self, msg, gripper, fingertip):
         """
         Publish the following topics
-        - wrench(geometry_msgs/WrenchStamped), wrench value for each PFS board
-        - force(geometry_msgs/Vector3), force value for each force sensor
+        - wrench(geometry_msgs/WrenchStamped), wrench value. One topic per PFS board.
+        - force(std_msgs/Float32), force value. One topic per force sensor.
         """
         header = Header()
         header.stamp = msg.header.stamp
@@ -191,7 +191,7 @@ class ConvertPFS(object):
     def publish_imu(self, msg, gripper, fingertip):
         """
         Publish the following topic
-        - imu(sensor_msgs/Imu), IMU value for PFS A board
+        - imu(sensor_msgs/Imu), IMU value. One topic per PFS A board.
         """
         imu = msg.imu
         # Gyro

--- a/scripts/convert_pfs.py
+++ b/scripts/convert_pfs.py
@@ -6,21 +6,22 @@ import rospy
 from pr2_fingertip_sensors.msg import PR2FingertipSensor
 from sensor_msgs.msg import Imu, PointCloud2, PointField
 import sensor_msgs.point_cloud2 as pc2
-from std_msgs.msg import Header
+from std_msgs.msg import Float32, Header
 
 
 class ConvertPFS(object):
     """
-    Convert PR2FingertipSensor message into proximity, force and imu message
-    - proximity(sensor_msgs/PointCloud2)
-    - force(geometry_msgs/WrenchStamped)
-    - imu(sensor_msgs/Imu)
+    Convert PR2FingertipSensor message into the following messages
+    - proximity_cloud(sensor_msgs/PointCloud2), pointcloud calculated from each proximity sensor
+    - proximity_distance(std_msgs/Float32), distance calculated from each proximity sensor
+    - wrench(geometry_msgs/WrenchStamped), wrench value for each PFS board
+    - force(geometry_msgs/Vector3), force value for each force sensor
+    - imu(sensor_msgs/Imu), IMU value for PFS A board
     """
     def __init__(self):
         self.grippers = ['l_gripper', 'r_gripper']
         self.fingertips = ['l_fingertip', 'r_fingertip']
-        self.parts = [
-            'pfs_a_front', 'pfs_b_top', 'pfs_b_back', 'pfs_b_left', 'pfs_b_right']
+        self.parts = ['pfs_a_front', 'pfs_b_top', 'pfs_b_back', 'pfs_b_left', 'pfs_b_right']
         self.fields = [PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
                        PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
                        PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1)]
@@ -33,25 +34,26 @@ class ConvertPFS(object):
                 self.pub[gripper][fingertip] = {}
                 for part in self.parts:
                     self.pub[gripper][fingertip][part] = {}
-                    sensors = ['proximity', 'force', 'imu']
-                    msg_types = [PointCloud2, WrenchStamped, Imu]
+                    sensors = ['proximity_distance', 'proximity_cloud', 'wrench', 'force', 'imu']
+                    msg_types = [Float32, PointCloud2, WrenchStamped, Float32, Imu]
                     for sensor, msg_type in zip(sensors, msg_types):
                         if sensor == 'imu' and part != 'pfs_a_front':
-                            continue  # PFS B does not have IMU
-                        self.pub[gripper][fingertip][part][sensor] = rospy.Publisher(
-                            '/pfs/{}/{}/{}/{}'.format(
-                                gripper, fingertip, part, sensor),
-                            msg_type, queue_size=1)
-                        # For Proximity sensors,
-                        # publish proximity cloud topic for RViz visualization
-                        if sensor == 'proximity':
+                            # PFS B does not have IMU
+                            continue
+                        # For imu and wrench, publish value for each board
+                        if sensor in ['imu', 'wrench']:
+                            self.pub[gripper][fingertip][part][sensor] = rospy.Publisher(
+                                '/pfs/{}/{}/{}/{}'.format(
+                                    gripper, fingertip, part, sensor),
+                                msg_type, queue_size=1)
+                        # For proximity and force sensors, publish value for each sensor
+                        if sensor in ['proximity_distance', 'proximity_cloud', 'force']:
                             self.pub[gripper][fingertip][part][sensor] = {}
                             for i in range(self.sensor_num(part)):
                                 self.pub[gripper][fingertip][part][sensor][i] = rospy.Publisher(
                                     '/pfs/{}/{}/{}/{}/{}'.format(
                                         gripper, fingertip, part, sensor, i),
                                     msg_type, queue_size=1)
-
                 # Subscriber
                 # Create subscribers at the last of __init__ to avoid
                 # 'object has no attribute ...' error
@@ -67,8 +69,11 @@ class ConvertPFS(object):
         """
         gripper = args[0]
         fingertip = args[1]
-        self.publish_pointcloud(msg, gripper, fingertip)
-        self.publish_wrenchstamped(msg, gripper, fingertip)
+        # Publish proximity distance and proximity cloud
+        self.publish_proximity(msg, gripper, fingertip)
+        # Publish each force sensor value and publish wrench value for each board
+        self.publish_force(msg, gripper, fingertip)
+        # Publish imu value for PFS A board
         self.publish_imu(msg, gripper, fingertip)
 
     def sensor_num(self, part):
@@ -125,13 +130,18 @@ class ConvertPFS(object):
         b = self.pfs_params[gripper][fingertip]['proximity_b'][index]
         if a == 0:
             # This means the calibration process was not done or failed.
-            distance = None
+            distance = float('inf')
         else:
             distance = math.sqrt(
                 a / max(0.1, proximity - b))  # unit: [m]
         return distance
 
-    def publish_pointcloud(self, msg, gripper, fingertip):
+    def publish_proximity(self, msg, gripper, fingertip):
+        """
+        Publish the following topics
+        - proximity_cloud(sensor_msgs/PointCloud2), pointcloud calculated from each proximity sensor
+        - proximity_distance(std_msgs/Float32), distance calculated from each proximity sensor
+        """
         header = Header()
         header.stamp = msg.header.stamp
         for part in self.parts:
@@ -144,12 +154,19 @@ class ConvertPFS(object):
                 distance = self.proximity_to_distance(
                     msg.proximity[index], gripper, fingertip, part, i)
                 # Distance is under 0.1[m], it is regarded as reliable
-                if distance is not None and distance < 0.1:
+                if distance < 0.1:
+                    dist_msg = Float32(data=distance)
+                    self.pub[gripper][fingertip][part]['proximity_distance'][i].publish(dist_msg)
                     point = [0, 0, distance]
                     prox_msg = pc2.create_cloud(header, self.fields, [point])
-                    self.pub[gripper][fingertip][part]['proximity'][i].publish(prox_msg)
+                    self.pub[gripper][fingertip][part]['proximity_cloud'][i].publish(prox_msg)
 
-    def publish_wrenchstamped(self, msg, gripper, fingertip):
+    def publish_force(self, msg, gripper, fingertip):
+        """
+        Publish the following topics
+        - wrench(geometry_msgs/WrenchStamped), wrench value for each PFS board
+        - force(geometry_msgs/Vector3), force value for each force sensor
+        """
         header = Header()
         header.stamp = msg.header.stamp
         for part in self.parts:
@@ -161,14 +178,21 @@ class ConvertPFS(object):
                 # Convert force into WrenchStamped
                 preload = self.pfs_params[gripper][fingertip]['preload'][index]
                 force_scale = self.pfs_params[gripper][fingertip]['force_scale'][index]
-                average_force += force_scale * (msg.force[index] - preload) / float(sensor_num)
+                force = msg.force[index] - preload
+                force_msg = Float32(data=force)
+                self.pub[gripper][fingertip][part]['force'][i].publish(force_msg)
+                average_force += force_scale * force / float(sensor_num)
             # Publish force
             force_msg = WrenchStamped()
             force_msg.header = header
             force_msg.wrench.force.z = average_force
-            self.pub[gripper][fingertip][part]['force'].publish(force_msg)
+            self.pub[gripper][fingertip][part]['wrench'].publish(force_msg)
 
     def publish_imu(self, msg, gripper, fingertip):
+        """
+        Publish the following topic
+        - imu(sensor_msgs/Imu), IMU value for PFS A board
+        """
         imu = msg.imu
         # Gyro
         gyro = imu.angular_velocity


### PR DESCRIPTION
各近接センサから計算された距離と力センサの値をpublishするようにしました。
READMEやconvert_pfs.pyのdocsにも書いていますが、今のところは以下の5つのトピックを出しています。

- proximity_cloud(sensor_msgs/PointCloud2), 各近接センサから計算された点群。センサごとに1トピック。
- proximity_distance(std_msgs/Float32), 各近接センサから計算された距離。センサごとに1トピック。
- wrench(geometry_msgs/WrenchStamped),力センサから計算されたレンチ。PFS基板ごとに1トピック。
- force(geometry_msgs/Vector3), 力センサから得られる力の値。センサごとに1トピック。
- imu(sensor_msgs/Imu), IMUの値。PFS A基板ごとに1トピック。