### PR TITLE
Warn when there is 0 preload force sensor

### DIFF
--- a/launch/calibrate_pfs.launch
+++ b/launch/calibrate_pfs.launch
@@ -1,4 +1,9 @@
 <launch>
+
+  <!-- Load default pfs sensor params -->
+  <rosparam command="load" file="$(find pr2_fingertip_sensors)/data/pfs_params.yaml" />
+
+  <!-- Launch ROS nodes for pfs sensor calibration -->
   <node name="parse_pfs" pkg="pr2_fingertip_sensors" type="parse_pfs.py" output="screen" />
   <node name="calibrate_pfs" pkg="pr2_fingertip_sensors" type="calibrate_pfs.py" output="screen" />
 </launch>

--- a/scripts/calibrate_pfs.py
+++ b/scripts/calibrate_pfs.py
@@ -108,6 +108,12 @@ class CalibratePFS(object):
                 # Set dummy pfs data in case not all fingers have sensors
                 if len(force) == 0:
                     force = [0] * 24
+                else:
+                    if 0 in force:
+                        rospy.logwarn('There is 0 force value in {} {}'.format(
+                            gripper, fingertip))
+                        rospy.logwarn('force value: {}'.format(
+                            force))
                 rospy.set_param(
                     '/pfs/{}/{}/preload'.format(gripper, fingertip),
                     force)


### PR DESCRIPTION
力センサのキャリブレーションをした時に、予圧が0の力センサがあったらwarningを出すようにしました。