### PR TITLE
Publish each force as WrenchStamped

### DIFF
--- a/config/pfs.rviz
+++ b/config/pfs.rviz
@@ -1277,76 +1277,362 @@ Visualization Manager:
           Name: ProximityCloud
         - Class: rviz/Group
           Displays:
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 4
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/4
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 5
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/5
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 6
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/6
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 7
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/force/7
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: A_Front
-              Topic: /pfs/l_gripper/l_fingertip/pfs_a_front/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Top
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_top/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Back
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_back/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Left
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_left/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Right
-              Topic: /pfs/l_gripper/l_fingertip/pfs_b_right/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
           Enabled: true
           Name: Wrench
         - Alpha: 1
@@ -2108,76 +2394,362 @@ Visualization Manager:
           Name: ProximityCloud
         - Class: rviz/Group
           Displays:
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 4
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/4
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 5
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/5
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 6
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/6
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 7
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/force/7
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: A_Front
-              Topic: /pfs/l_gripper/r_fingertip/pfs_a_front/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Top
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_top/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Back
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_back/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Left
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_left/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Right
-              Topic: /pfs/l_gripper/r_fingertip/pfs_b_right/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
           Enabled: true
           Name: Wrench
         - Alpha: 1
@@ -2939,76 +3511,362 @@ Visualization Manager:
           Name: ProximityCloud
         - Class: rviz/Group
           Displays:
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 4
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/4
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 5
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/5
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 6
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/6
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 7
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/force/7
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: A_Front
-              Topic: /pfs/r_gripper/l_fingertip/pfs_a_front/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Top
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_top/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Back
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_back/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Left
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_left/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Right
-              Topic: /pfs/r_gripper/l_fingertip/pfs_b_right/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
           Enabled: true
           Name: Wrench
         - Alpha: 1
@@ -3770,76 +4628,362 @@ Visualization Manager:
           Name: ProximityCloud
         - Class: rviz/Group
           Displays:
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 4
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/4
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 5
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/5
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 6
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/6
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 7
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/force/7
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: A_Front
-              Topic: /pfs/r_gripper/r_fingertip/pfs_a_front/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Top
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_top/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Back
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_back/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Left
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_left/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
-            - Alpha: 1
-              Arrow Width: 0.10000000149011612
-              Class: rviz/WrenchStamped
+            - Class: rviz/Group
+              Displays:
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 0
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/force/0
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 1
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/force/1
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 2
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/force/2
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
+                - Alpha: 1
+                  Arrow Width: 0.019999999552965164
+                  Class: rviz/WrenchStamped
+                  Enabled: true
+                  Force Arrow Scale: 0.009999999776482582
+                  Force Color: 204; 51; 51
+                  Hide Small Values: false
+                  History Length: 1
+                  Name: 3
+                  Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/force/3
+                  Torque Arrow Scale: 0.009999999776482582
+                  Torque Color: 204; 204; 51
+                  Unreliable: false
+                  Value: true
               Enabled: true
-              Force Arrow Scale: 0.03
-              Force Color: 204; 51; 51
-              Hide Small Values: false
-              History Length: 1
               Name: B_Right
-              Topic: /pfs/r_gripper/r_fingertip/pfs_b_right/wrench
-              Torque Arrow Scale: 0.03
-              Torque Color: 204; 204; 51
-              Unreliable: false
-              Value: true
           Enabled: true
           Name: Wrench
         - Alpha: 1
@@ -3898,10 +5042,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.40479743480682373
+      Pitch: 0.5497972965240479
       Target Frame: base_link
       Value: Orbit (rviz)
-      Yaw: 5.632055759429932
+      Yaw: 4.897051811218262
     Saved: ~
 Window Geometry:
   Displays:
@@ -3909,7 +5053,7 @@ Window Geometry:
   Height: 1025
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd0000000400000000000001e300000363fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004b0069006e00650063007400430061006d00650072006102000000830000013e0000026c000001bafb00000018004e006100720072006f007700430061006d00650072006100000002cb000000be0000000000000000000000010000010f000007cefc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000007ce000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000005540000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001f400000363fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004b0069006e00650063007400430061006d00650072006102000000830000013e0000026c000001bafb00000018004e006100720072006f007700430061006d00650072006100000002cb000000be0000000000000000000000010000010f000007cefc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000007ce000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000005430000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:


### PR DESCRIPTION
各力センサの値を別々の矢印で表示するようにして、近接+力覚が分布していることが分かりやすいようにしました。

以下の図は、人間がPR2の指を握っている時の様子です。
![Screenshot from 2022-11-24 18-31-08](https://user-images.githubusercontent.com/19769486/203748219-ea5e3e65-2a30-4970-832b-0d4e96ee7353.png)
