### PR TITLE
Show stdout of symlink_arduino_libraries.sh in catkin build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,5 +35,6 @@ install(DIRECTORY scripts
 # Create symlink for Arduino sketches
 execute_process(COMMAND
   bash "-c" "${CMAKE_SOURCE_DIR}/scripts/symlink_arduino_libraries.sh"
+  OUTPUT_VARIABLE COMMAND_RESULT
   )
-message("Create symlink from arduino_libraries directory to each arduino sketches.")
+message(${COMMAND_RESULT})

--- a/scripts/symlink_arduino_libraries.sh
+++ b/scripts/symlink_arduino_libraries.sh
@@ -4,6 +4,7 @@ PKG_PATH=$(dirname $SCRIPTS_DIR)
 ARDUINO_LIBRARY_DIR=$PKG_PATH/arduino_libraries
 ARDUINO_SKETCH_DIR=$PKG_PATH/sketches
 
+echo "Create symlink from arduino_libraries directory to each arduino sketches."
 for SKETCH in $(ls $ARDUINO_SKETCH_DIR); do
     SKETCH_DIR=$ARDUINO_SKETCH_DIR/$SKETCH
     if [ -d $SKETCH_DIR ]; then


### PR DESCRIPTION
catkin buildのstdoutに、`execute_process`から呼び出したシェルスクリプトのstdoutを表示するようにしました。（デバッグ用です）