### PR TITLE
Mute M5Stack speaker to avoid noise

### DIFF
--- a/sketches/README.md
+++ b/sketches/README.md
@@ -32,3 +32,10 @@ rosrun rosserial_python serial_node.py _baud:=57600 _port:=<your_m5stack_device>
 # NOTE
 
 The directory `sketch/**/symlink_libs` is automatically created by `catkin build` and the files in the directory is ignored by git. Do not place your original header files here.
+
+If M5Stack is unable to communicate properly with PFS, try the following steps. This will allow the timing of communication between the two to be matched.
+
+- Disconnect the M5Stack and PFS cables
+- Double-click the button on the M5Stack to turn off the power
+- Click the button on the M5Stack to turn it on
+- Connect the M5Stack and PFS cables

--- a/sketches/publish_PFS/publish_PFS.ino
+++ b/sketches/publish_PFS/publish_PFS.ino
@@ -10,6 +10,8 @@
 void setup() {
   // Setup M5Stack
   M5.begin();
+  M5.Speaker.begin();
+  M5.Speaker.mute();
   setup_nodehandle();
   begin_pfs();
 }


### PR DESCRIPTION
M5Stackのファームウェアでスピーカをミュートにすることで、ノイズが発生しないようにしました。
また、PFSとM5Stackの間で通信を行うための電源投入の手順をREADMEに書きました。