### PR TITLE
M5Stackが複数のI2Cデバイスを読めるようにする

### DIFF
--- a/arduino_libraries/pfs_ros.h
+++ b/arduino_libraries/pfs_ros.h
@@ -9,7 +9,7 @@
 // ROS node handle.
 ros::NodeHandle nh;
 pr2_fingertip_sensors::PR2FingertipSensor pfs_msg;
-#if (defined HARDWARE_SERIAL) || (defined SOFTWARE_SERIAL)
+#if (defined SOFTWARE_SERIAL) || (defined HARDWARE_SERIAL)
   ros::Publisher pfs_pub("/pfs/from_uart", &pfs_msg);
 #endif
 #if (defined I2C_MASTER)
@@ -41,19 +41,36 @@ void set_pfs_fields(struct pfs_sensors* sensors,
   return;
 }
 
-void get_pfs_msg (pr2_fingertip_sensors::PR2FingertipSensor* pfs_msg) {
+void get_pfs_msg (pr2_fingertip_sensors::PR2FingertipSensor* pfs_msg, uint8_t pfs_address = 0x01) {
   // Get sensor data
   // If you use HARD/SOFTWARE Serial, stop them before publishing rostopic
   #if (defined SOFTWARE_SERIAL) || (defined HARDWARE_SERIAL)
     begin_pfs();
   #endif
   struct pfs_sensors sensors;
-  read_sensors(&sensors);
+  read_sensors(&sensors, pfs_address);
   #if (defined SOFTWARE_SERIAL) || (defined HARDWARE_SERIAL)
     end_pfs_serial();
   #endif
 
   set_pfs_fields(&sensors, pfs_msg);
   pfs_msg->header.stamp = nh.now();
-  pfs_msg->header.frame_id = "pfs_link";
+  char frame_id[15];
+  sprintf(frame_id, "pfs_link_%d", pfs_address);
+  pfs_msg->header.frame_id = frame_id;
+}
+
+void publish_pfs () {
+  #if (defined SOFTWARE_SERIAL) || (defined HARDWARE_SERIAL)
+    // Make sure that other Serial is not used during rosserial communication
+    get_pfs_msg(&pfs_msg);
+    pfs_pub.publish(&pfs_msg);
+  #endif
+  #if (defined I2C_MASTER)
+    for(int i=0; i<sizeof(pfs_addresses)/sizeof(uint8_t); i++) {
+      get_pfs_msg(&pfs_msg, pfs_addresses[i]);
+      pfs_pub.publish(&pfs_msg);
+    }
+  #endif
+  nh.spinOnce();
 }

--- a/sketches/publish_PFS/publish_PFS.ino
+++ b/sketches/publish_PFS/publish_PFS.ino
@@ -5,6 +5,8 @@
 #define I2C_MASTER
 // #define SOFTWARE_SERIAL
 // #define HARDWARE_SERIAL
+#define PFS_ADDRESSES {0x01}
+// #define PFS_ADDRESSES {0x01, 0x02}
 #include "symlink_libs/pfs_ros.h"
 
 void setup() {
@@ -17,11 +19,5 @@ void setup() {
 }
 
 void loop() {
-  // Read sensor data and set ROS msg
-  get_pfs_msg(&pfs_msg);
-
-  // Publish ROS message
-  // Make sure that other Serial is not used during rosserial communication
-  pfs_pub.publish(&pfs_msg);
-  nh.spinOnce();
+  publish_pfs();
 }

--- a/sketches/receive_PFS/receive_PFS.ino
+++ b/sketches/receive_PFS/receive_PFS.ino
@@ -3,8 +3,10 @@
 #define I2C_MASTER
 // #define SOFTWARE_SERIAL
 // #define HARDWARE_SERIAL
+#define PFS_ADDRESSES {0x01}
+// #define PFS_ADDRESSES {0x01, 0x02}
 #include "symlink_libs/pfs.h"
-
+  
 void setup() {
   M5.begin();
   Serial.begin(115200);
@@ -14,7 +16,5 @@ void setup() {
 }
 
 void loop() {
-  struct pfs_sensors sensors;
-  read_sensors(&sensors);
-  print_sensors(&sensors); // For debug
+  receive_pfs();
 }


### PR DESCRIPTION
以下のようにすることで、複数のI2Cデバイス（PFS）と通信できるようにしました。

```
#define PFS_ADDRESSES {0x01, 0x02}
```