### PR TITLE
Get map() to return list for python3

### DIFF
--- a/scripts/calibrate_pfs.py
+++ b/scripts/calibrate_pfs.py
@@ -90,7 +90,7 @@ class CalibratePFS(object):
                         a = 0  # dummy value
                     return a
 
-                proximity_a = map(_calc_a, proximity, proximity_b)
+                proximity_a = list(map(_calc_a, proximity, proximity_b))
                 # Set 'a' to rosparam
                 rospy.set_param(
                     '/pfs/{}/{}/proximity_a'.format(gripper, fingertip),


### PR DESCRIPTION
map() returns map object in Python3, so it has to be converted into list.
This change worked in Python2, too.